### PR TITLE
Fix #46: Support database default values by preventing NULL insertion for unset columns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         CLAILS_MIGRATION_DIR_0002: ${{ github.workspace }}/test/data/0002-join-test
         CLAILS_MIGRATION_DIR_0003: ${{ github.workspace }}/test/data/0003-save-test
         CLAILS_MIGRATION_DIR_0004: ${{ github.workspace }}/test/data/0004-lock-test
+        CLAILS_MIGRATION_DIR_0005: ${{ github.workspace }}/test/data/0005-default-value-test
         CLAILS_SQLITE3_DATABASE: ${{ github.workspace }}
         CLAILS_MYSQL_DATABASE: clails_test
         CLAILS_MYSQL_USERNAME: root

--- a/src/model/impl/postgresql.lisp
+++ b/src/model/impl/postgresql.lisp
@@ -119,6 +119,48 @@
 (defun type-convert (type)
   (cdr (assoc type *postgresql-type-convert*)))
 
+
+(defun convert-default-value (value column-type)
+  "Convert Lisp value to SQL DEFAULT clause string for PostgreSQL.
+
+   @param value [t] Default value in Lisp representation
+   @param column-type [keyword] Column type (:string, :integer, :boolean, etc.)
+   @return [string] SQL DEFAULT clause value
+   "
+  (cond
+    ;; Special keywords
+    ((eq value :null) "NULL")
+    ((eq value :current-timestamp) "CURRENT_TIMESTAMP")
+
+    ;; Boolean type - PostgreSQL has native boolean type
+    ((eq column-type :boolean)
+     (cond ((eq value t) "TRUE")
+           ((null value) "FALSE")
+           (t (error "Invalid boolean default value: ~A. Use T or NIL." value))))
+
+    ;; Numeric types
+    ((numberp value) (format nil "~A" value))
+
+    ;; String types - need to quote the value
+    ((and (or (eq column-type :string)
+              (eq column-type :text))
+          (stringp value))
+     (format nil "'~A'" value))
+
+    ;; Datetime types
+    ((and (or (eq column-type :datetime)
+              (eq column-type :date)
+              (eq column-type :time))
+          (stringp value))
+     (format nil "'~A'" value))
+
+    ;; Fallback for other string values
+    ((stringp value) value)
+
+    ;; Error for unsupported types
+    (t (error "Unsupported default value type: ~A for column type ~A"
+              value column-type))))
+
 (defmethod create-table-impl ((database-type <database-type-postgresql>) connection &key table columns constraints)
   (declare (ignore database-type))
   (mandatory-check table columns)
@@ -256,7 +298,10 @@
          (not-null-p (getf attr :not-null))
          (primary-key-p (getf attr :primary-key))
          (auto-increment-p (getf attr :auto-increment))
-         (default-value (getf attr :default-value)))
+         (default-value-raw (getf attr :default-value))
+         ;; Convert default value to SQL string
+         (default-value (when default-value-raw
+                          (convert-default-value default-value-raw type))))
 
     (check-type-valid type)
     (create-column column-name type not-null-p primary-key-p auto-increment-p default-value)))

--- a/src/model/impl/sqlite3.lisp
+++ b/src/model/impl/sqlite3.lisp
@@ -113,6 +113,48 @@
 (defun type-convert (type)
   (cdr (assoc type *sqlite3-type-convert*)))
 
+
+(defun convert-default-value (value column-type)
+  "Convert Lisp value to SQL DEFAULT clause string for SQLite3.
+
+   @param value [t] Default value in Lisp representation
+   @param column-type [keyword] Column type (:string, :integer, :boolean, etc.)
+   @return [string] SQL DEFAULT clause value
+   "
+  (cond
+    ;; Special keywords
+    ((eq value :null) "NULL")
+    ((eq value :current-timestamp) "CURRENT_TIMESTAMP")
+
+    ;; Boolean type - SQLite stores as INTEGER (0 or 1)
+    ((eq column-type :boolean)
+     (cond ((eq value t) "1")
+           ((null value) "0")
+           (t (error "Invalid boolean default value: ~A. Use T or NIL." value))))
+
+    ;; Numeric types
+    ((numberp value) (format nil "~A" value))
+
+    ;; String types - need to quote the value
+    ((and (or (eq column-type :string)
+              (eq column-type :text))
+          (stringp value))
+     (format nil "'~A'" value))
+
+    ;; Datetime types
+    ((and (or (eq column-type :datetime)
+              (eq column-type :date)
+              (eq column-type :time))
+          (stringp value))
+     (format nil "'~A'" value))
+
+    ;; Fallback for other string values
+    ((stringp value) value)
+
+    ;; Error for unsupported types
+    (t (error "Unsupported default value type: ~A for column type ~A"
+              value column-type))))
+
 (defmethod create-table-impl ((database-type <database-type-sqlite3>) connection &key table columns constraints)
   (declare (ignore database-type))
   (mandatory-check table columns)
@@ -253,7 +295,10 @@
          (not-null-p (getf attr :not-null))
          (primary-key-p (getf attr :primary-key))
          (auto-increment-p (getf attr :auto-increment))
-         (default-value (getf attr :default-value))
+         (default-value-raw (getf attr :default-value))
+         ;; Convert default value to SQL string
+         (default-value (when default-value-raw
+                          (convert-default-value default-value-raw type)))
          (precision (when (or (eq type :decimal)
                               (eq type :float))
                       (getf attr :precision)))

--- a/test/data/0005-default-value-test/db/migrate/20251019-000000-create-table.lisp
+++ b/test/data/0005-default-value-test/db/migrate/20251019-000000-create-table.lisp
@@ -1,0 +1,15 @@
+(in-package #:clails-test/model/db/default-value)
+
+(defmigration "20251019-000000-create-table"
+ (:up #'(lambda (conn)
+          (create-table conn :table "product"
+                             :columns '(("name" :type :string
+                                                :not-null T)
+                                        ("status" :type :string
+                                                  :default-value "active")
+                                        ("priority" :type :integer
+                                                    :default-value 0)
+                                        ("is-published" :type :boolean
+                                                        :default-value T))))
+  :down #'(lambda (conn)
+           (drop-table conn :table "product"))))

--- a/test/model/default-value.lisp
+++ b/test/model/default-value.lisp
@@ -1,0 +1,190 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/default-value
+  (:use #:cl
+        #:rove
+        #:clails/model/query)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/base-model
+                #:<base-model>
+                #:defmodel
+                #:ref
+                #:ref-error
+                #:has-error-p
+                #:frozen-p
+                #:clear-error
+                #:validate))
+
+(defpackage #:clails-test/model/db/default-value
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-column
+                #:add-index
+                #:drop-table
+                #:drop-column
+                #:drop-index))
+
+(in-package #:clails-test/model/default-value)
+
+(setup
+  ;; clear table-information
+  (clrhash clails/model/base-model::*table-information*)
+  ;; define models
+  (defmodel <product> (<base-model>)
+    (:table "product"))
+
+ (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+ (setf clails/environment:*project-environment* :test)
+ (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                     :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                     :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                     :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                     :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+ (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0005" "/app/test/data/0005-default-value-test"))
+ (uiop:setup-temporary-directory)
+ (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+ (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+ (clails/model/migration::db-create)
+ (clails/model/migration::db-migrate)
+ (clails/model/base-model::initialize-table-information)
+ (clails/model/connection:startup-connection-pool))
+
+
+(teardown
+ (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+ (clails/model/connection:shutdown-connection-pool))
+
+
+(deftest test-insert-with-default-values
+  (testing "insert record without setting optional columns should use database default values"
+    (let* ((product (make-instance '<product>)))
+      ;; Only set required column
+      (setf (ref product :name) "Test Product")
+      
+      ;; Save the record
+      (save product)
+      
+      (ok (ref product :id)
+          "Product should be saved with an ID")
+      
+      ;; Retrieve the record from database to verify default values
+      (let* ((query (query <product>
+                           :as :product
+                           :where (:= (:product :id) :id)))
+             (retrieved (car (execute-query query (list :id (ref product :id))))))
+        
+        (ok retrieved
+            "Product should be retrieved from database")
+        
+        (ok (string= (ref retrieved :name) "Test Product")
+            "Name should match the set value")
+        
+        (ok (string= (ref retrieved :status) "active")
+            "Status should have database default value 'active'")
+        
+        (ok (= (ref retrieved :priority) 0)
+            "Priority should have database default value 0")
+        
+        (ok (eq (ref retrieved :is-published) T)
+            "Is-published should have database default value TRUE"))))
+
+  (testing "insert record with some optional columns set should use database defaults for unset columns"
+    (let* ((product (make-instance '<product>)))
+      ;; Set required column and one optional column
+      (setf (ref product :name) "Another Product")
+      (setf (ref product :status) "draft")
+      
+      ;; Save the record
+      (save product)
+      
+      ;; Retrieve the record from database
+      (let* ((query (query <product>
+                           :as :product
+                           :where (:= (:product :id) :id)))
+             (retrieved (car (execute-query query (list :id (ref product :id))))))
+        
+        (ok (string= (ref retrieved :name) "Another Product")
+            "Name should match the set value")
+        
+        (ok (string= (ref retrieved :status) "draft")
+            "Status should match the explicitly set value")
+        
+        (ok (= (ref retrieved :priority) 0)
+            "Priority should have database default value 0")
+        
+        (ok (eq (ref retrieved :is-published) T)
+            "Is-published should have database default value TRUE"))))
+
+  (testing "insert record with all columns explicitly set should not use defaults"
+    (let* ((product (make-instance '<product>)))
+      ;; Set all columns explicitly
+      (setf (ref product :name) "Full Product")
+      (setf (ref product :status) "archived")
+      (setf (ref product :priority) 10)
+      (setf (ref product :is-published) NIL)
+      
+      ;; Save the record
+      (save product)
+      
+      ;; Retrieve the record from database
+      (let* ((query (query <product>
+                           :as :product
+                           :where (:= (:product :id) :id)))
+             (retrieved (car (execute-query query (list :id (ref product :id))))))
+        
+        (ok (string= (ref retrieved :name) "Full Product")
+            "Name should match the set value")
+        
+        (ok (string= (ref retrieved :status) "archived")
+            "Status should match the explicitly set value")
+        
+        (ok (= (ref retrieved :priority) 10)
+            "Priority should match the explicitly set value")
+        
+        (ok (null (ref retrieved :is-published))
+            "Is-published should match the explicitly set value (NULL/FALSE)"))))
+
+  (testing "insert record using make-record helper should also respect defaults"
+    (let* ((product (make-record '<product> :name "Helper Product" :priority 5)))
+      ;; Save the record
+      (save product)
+      
+      ;; Retrieve the record from database
+      (let* ((query (query <product>
+                           :as :product
+                           :where (:= (:product :id) :id)))
+             (retrieved (car (execute-query query (list :id (ref product :id))))))
+        
+        (ok (string= (ref retrieved :name) "Helper Product")
+            "Name should match the set value")
+        
+        (ok (string= (ref retrieved :status) "active")
+            "Status should have database default value 'active'")
+        
+        (ok (= (ref retrieved :priority) 5)
+            "Priority should match the explicitly set value")
+        
+        (ok (eq (ref retrieved :is-published) T)
+            "Is-published should have database default value TRUE")))))
+
+
+(deftest test-ref-with-unset-columns
+  (testing "ref should return NIL for valid columns that have not been set"
+    (let ((product (make-instance '<product>)))
+      
+      (ok (null (ref product :name))
+          "Unset column 'name' should return NIL")
+      
+      (ok (null (ref product :status))
+          "Unset column 'status' should return NIL")
+      
+      (ok (null (ref product :priority))
+          "Unset column 'priority' should return NIL")))
+
+  (testing "ref should raise error for non-existent columns"
+    (let ((product (make-instance '<product>)))
+      
+      (ok (signals (ref product :non-existent-column))
+          "Accessing non-existent column should raise an error"))))


### PR DESCRIPTION
Overview

This PR fixes issue #46 where insert1 was inserting NULL for all columns,
overriding database default values. The root cause was that all columns were
initialized with NIL in the data hash table, and insert1 included all columns in
the INSERT statement regardless of whether they were explicitly set by the user.

Changes

1. Modified insert1 to only insert explicitly set columns

  - File: src/model/query.lisp
  - Updated fetch-columns function to check dirty-flag for INSERT operations
  - Only columns with dirty-flag set are included in the INSERT statement
  - Database default values are now properly applied to unset columns

2. Enhanced (setf ref) method to track explicitly set values

  - File: src/model/base-model.lisp
  - Modified to set dirty-flag when a key doesn't exist in the data hash table
  - Distinguishes between database columns and relations (only sets dirty-flag for database columns)
  - Handles the case where users explicitly set a column to NIL

3. Implemented convert-default-value function for all database types

  - Files: src/model/impl/mysql.lisp, src/model/impl/postgresql.lisp, src/model/impl/sqlite3.lisp
  - Added type-aware conversion function for default values in migrations
  - Supports intuitive Lisp types:
    - String: "active" → 'active' (SQL string literal)
    - Integer: 0 → 0
    - Boolean: T/NIL → 1/0 (MySQL/SQLite) or TRUE/FALSE (PostgreSQL)
    - Special keywords: :null, :current-timestamp
  - Updated parse-column function to apply conversion

4. Added comprehensive tests

  - Files: test/model/default-value.lisp, test/data/0005-default-value-test/
  - Tests verify that database default values are applied when columns are not explicitly set
  - Tests verify that explicitly set values (including NIL) are correctly inserted
  - All existing tests continue to pass

Benefits

  - Database default values work correctly: Unset columns now use their database-defined default values
  - Intuitive API: Migration files can use natural Lisp types for default values instead of SQL strings
  - Explicit NIL handling: Users can explicitly set a column to NIL/FALSE when needed
  - No breaking changes: All existing tests pass

Example

Before (didn't work as expected):

```lisp
  (let ((product (make-instance '<product>)))
    (setf (ref product :name) "Test Product")
    (save product))
  ;; Result: status=NULL, priority=NULL, is-published=NULL
```

After (works correctly):

```lisp
  (let ((product (make-instance '<product>)))
    (setf (ref product :name) "Test Product")
    (save product))
  ;; Result: status='active', priority=0, is-published=TRUE (from database defaults)
```

Migration syntax improvement:

```lisp
  ;; Old way (SQL strings)
  ("status" :type :string :default-value "'active'")
  ("priority" :type :integer :default-value "0")
  ("is-published" :type :boolean :default-value "1")

  ;; New way (Lisp types)
  ("status" :type :string :default-value "active")
  ("priority" :type :integer :default-value 0)
  ("is-published" :type :boolean :default-value T)
```

Test Results

  ✓ 25 tests completed
  Summary: All 25 tests passed.