### PR TITLE
implement db:migrate version control and db:rollback command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         CLAILS_MIGRATION_DIR_0004: ${{ github.workspace }}/test/data/0004-lock-test
         CLAILS_MIGRATION_DIR_0005: ${{ github.workspace }}/test/data/0005-default-value-test
         CLAILS_MIGRATION_DIR_0006: ${{ github.workspace }}/test/data/0006-transaction-test
+        CLAILS_MIGRATION_DIR_0007: ${{ github.workspace }}/test/data/0007-migration-kaizen-test
         CLAILS_SQLITE3_DATABASE: ${{ github.workspace }}
         CLAILS_MYSQL_DATABASE: clails_test
         CLAILS_MYSQL_USERNAME: root

--- a/clails-test.asd
+++ b/clails-test.asd
@@ -24,6 +24,7 @@
                #:clails-test/model/save
                #:clails-test/model/optimistic-lock
                #:clails-test/model/default-value
+               #:clails-test/model/migration
                #:clails-test/model/transaction
                #:clails-test/model/transaction/transaction-sqlite3
                #:clails-test/model/transaction/transaction-mysql

--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -51,15 +51,35 @@ exec ros -Q -- $0 "$@"
   (load-project)
   (clails/cmd:db/create))
 
-(defun db/migrate/up (&optional version)
-  (declare (ignore version))
+(defun db/migrate (&optional version)
   (load-project)
   (load "db/package.lisp")
-  (clails/cmd:db/migrate))
+  (if version
+      (clails/cmd:db/migrate :version version)
+      (clails/cmd:db/migrate)))
 
-(defun db/migrate/down (&optional version)
-  (declare (ignore version))
-  (format t "down~%"))
+(defun db/migrate/up (version)
+  (when (null version)
+     (format *error-output* "ERROR: VERSION parameter is required for db:migrate:up~%")
+     (uiop:quit 1))
+  (load-project)
+  (load "db/package.lisp")
+  (clails/cmd:db/migrate-up version))
+
+(defun db/migrate/down (version)
+  (when (null version)
+     (format *error-output* "ERROR: VERSION parameter is required for db:migrate:down~%")
+     (uiop:quit 1))
+  (load-project)
+  (load "db/package.lisp")
+  (clails/cmd:db/migrate-down version))
+
+(defun db/rollback (&optional step)
+  (load-project)
+  (load "db/package.lisp")
+  (if step
+      (clails/cmd:db/rollback :step (parse-integer step))
+      (clails/cmd:db/rollback)))
 
 (defun db/status ()
   (load-project)
@@ -116,11 +136,13 @@ exec ros -Q -- $0 "$@"
                (:command "db:create"
                 :function ,#'db/create)
                (:command "db:migrate"
-                :function ,#'db/migrate/up)
+                :function ,#'db/migrate)
                (:command "db:migrate:up"
                 :function ,#'db/migrate/up)
                (:command "db:migrate:down"
                 :function ,#'db/migrate/down)
+               (:command "db:rollback"
+                :function ,#'db/rollback)
                (:command "db:status"
                 :function ,#'db/status)
                (:command "generate:model"

--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -15,6 +15,9 @@
   (:import-from #:clails/model/migration
                 #:db-create
                 #:db-migrate
+                #:migrate-up-version
+                #:migrate-down-version
+                #:db-rollback
                 #:db-status)
   (:import-from #:clails/controller/base-controller
                 #:initialize-routing-tables)
@@ -31,6 +34,9 @@
            #:generate/scaffold
            #:db/create
            #:db/migrate
+           #:db/migrate-up
+           #:db/migrate-down
+           #:db/rollback
            #:db/status
            #:console
            #:server
@@ -115,13 +121,14 @@
    "
   (db-create))
 
-(defun db/migrate (&key (env :development))
+(defun db/migrate (&key (env :development) version)
   "Run pending database migrations for the specified environment.
 
    @param env [keyword] Environment name (:development, :test, :production, default: :development)
+   @param version [string] Migration name to migrate up to (optional). If nil, runs all pending migrations.
    @return [t] Migration execution result
    "
-  (db-migrate))
+  (db-migrate :version version))
 
 (defun db/status ()
   "Display the status of database migrations.
@@ -130,14 +137,38 @@
    "
   (db-status))
 
-(defun db/rollback ()
-  "Rollback the last database migration.
+(defun db/migrate-up (version &key (env :development))
+  "Run a specific database migration for the specified environment.
 
-   Not yet implemented.
-
-   @return [nil] Always returns nil
+   @param version [string] Migration name to apply (required)
+   @param env [keyword] Environment name (:development, :test, :production, default: :development)
+   @return [t] Migration execution result
+   @condition error Version parameter is required
    "
-  nil)
+  (when (null version)
+    (error "VERSION parameter is required for db:migrate:up"))
+  (migrate-up-version version))
+
+(defun db/migrate-down (version &key (env :development))
+  "Rollback a specific database migration for the specified environment.
+
+   @param version [string] Migration name to rollback (required)
+   @param env [keyword] Environment name (:development, :test, :production, default: :development)
+   @return [t] Rollback execution result
+   @condition error Version parameter is required
+   "
+  (when (null version)
+    (error "VERSION parameter is required for db:migrate:down"))
+  (migrate-down-version version))
+
+(defun db/rollback (&key (env :development) (step 1))
+  "Rollback database migrations for the specified environment.
+
+   @param env [keyword] Environment name (:development, :test, :production, default: :development)
+   @param step [integer] Number of migrations to rollback (default: 1)
+   @return [t] Rollback execution result
+   "
+  (db-rollback :step step))
 
 
 (defun console ()

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -8,7 +8,10 @@
                 #:generate/model
                 #:generate/migration
                 #:db/create
-                #:db/migrate)
+                #:db/migrate
+                #:db/migrate-up
+                #:db/migrate-down
+                #:db/rollback)
   (:import-from #:clails/model)
   (:import-from #:clails/view)
   (:import-from #:clails/middleware)
@@ -18,6 +21,9 @@
            #:generate/model
            #:generate/migration
            #:db/create
-           #:db/migrate))
+           #:db/migrate
+           #:db/migrate-up
+           #:db/migrate-down
+           #:db/rollback))
 (in-package #:clails/main)
 

--- a/src/model/impl/mysql.lisp
+++ b/src/model/impl/mysql.lisp
@@ -175,7 +175,8 @@
 (defmethod drop-column-impl ((database-type <database-type-mysql>) connection &key table column)
   (declare (ignore database-type))
   (mandatory-check table column)
-  (let ((query (gen-drop-column table column)))
+  (let* ((columns (if (listp column) column (list column)))
+         (query (gen-drop-column table columns)))
     (log.sql query :table table :column column)
     (dbi:do-sql connection query)))
 

--- a/src/model/impl/postgresql.lisp
+++ b/src/model/impl/postgresql.lisp
@@ -200,7 +200,8 @@
 (defmethod drop-column-impl ((database-type <database-type-postgresql>) connection &key table column)
   (declare (ignore database-type))
   (mandatory-check table column)
-  (let ((query (gen-drop-column table column)))
+  (let* ((columns (if (listp column) column (list column)))
+         (query (gen-drop-column table columns)))
     (log.sql query :table table :column column)
     (dbi:do-sql connection query)))
 

--- a/src/model/impl/sqlite3.lisp
+++ b/src/model/impl/sqlite3.lisp
@@ -194,9 +194,11 @@
 (defmethod drop-column-impl ((database-type <database-type-sqlite3>) connection &key table column)
   (declare (ignore database-type))
   (mandatory-check table column)
-  (let ((query (gen-drop-column table column)))
-    (log.sql query :table table :column column)
-    (dbi:do-sql connection query)))
+  (let ((columns (if (listp column) column (list column))))
+    (loop for col in columns
+          do (let ((query (gen-drop-column table (list col))))
+               (log.sql query :table table :column col)
+               (dbi:do-sql connection query)))))
 
 (defmethod drop-index-impl ((database-type <database-type-sqlite3>) connection &key table index)
   (declare (ignore database-type))

--- a/src/model/migration.lisp
+++ b/src/model/migration.lisp
@@ -26,6 +26,9 @@
            #:drop-index-impl
            #:db-create
            #:db-migrate
+           #:migrate-up-version
+           #:migrate-down-version
+           #:db-rollback
            #:check-type-valid))
 (in-package #:clails/model/migration)
 
@@ -68,7 +71,7 @@
 ;;;
 (defmacro defmigration (migration-name body)
   "Define a database migration with up and down functions.
-   
+
    @param migration-name [string] Unique name for this migration
    @param body [plist] Property list with :up and :down function specifications
    "
@@ -113,9 +116,9 @@
 
 (defun create-table (conn &rest args &key &allow-other-keys)
   "Create a new database table according to the database implementation.
-   
+
    Tracks the table definition and executes the database-specific implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name
    @param columns [list] List of column specifications
@@ -127,9 +130,9 @@
 
 (defun add-column (conn &rest args &key &allow-other-keys)
   "Add column to existing table according to the database implementation.
-   
+
    Updates the tracked table definition and executes the database-specific implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name
    @param columns [list] List of column specifications to add
@@ -145,7 +148,7 @@
 
 (defun add-index (conn &rest args &key &allow-other-keys)
   "Add index to table according to the database implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name
    @param index [string] Index name
@@ -155,9 +158,9 @@
 
 (defun drop-table (conn &rest args &key &allow-other-keys)
   "Drop table according to the database implementation.
-   
+
    Removes the table from tracked definitions and executes the database-specific implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name to drop
    "
@@ -171,9 +174,9 @@
 
 (defun drop-column (conn &rest args &key &allow-other-keys)
   "Drop column from table according to the database implementation.
-   
+
    Updates the tracked table definition and executes the database-specific implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name
    @param column [string] Column name to drop
@@ -195,7 +198,7 @@
 
 (defun drop-index (conn &rest args &key &allow-other-keys)
   "Drop index from table according to the database implementation.
-   
+
    @param conn [dbi:<dbi-connection>] Database connection
    @param table [string] Table name
    @param index [string] Index name to drop
@@ -204,26 +207,30 @@
 
 (defun db-create ()
   "Create database and migration table.
-   
+
    Implementation of db/create command.
    "
   (ensure-database)
   (ensure-migration-table))
 
-(defun db-migrate ()
+(defun db-migrate (&key version)
   "Load migration files and apply pending migrations.
-   
+
    Implementation of db/migrate command. Also exports schema file after migration.
+
+   @param version [string] Migration name to migrate up to (optional). If nil, runs all pending migrations.
    "
   (ensure-migration-table)
   (setf *migrations* nil)
   (load-migration-files)
-  (migrate-all)
+  (if version
+      (migrate-to-version version)
+      (migrate-all))
   (export-schema-file))
 
 (defun db-status ()
   "Display migration status.
-   
+
    Shows which migrations have been applied and which are pending.
    "
   (setf *migrations* nil)
@@ -234,7 +241,7 @@
 
 (defun check-type-valid (type)
   "Check if column type is valid.
-   
+
    @param type [keyword] Column type to validate
    @condition error Signaled when type is not in *type-list*
    "
@@ -283,6 +290,124 @@
          (up-fn (getf migration :up)))
     (funcall up-fn connection)
     (insert-migration connection migration-name)))
+
+(defun migrate-to-version (version)
+  "Apply migrations up to specified version.
+
+   @param version [string] Migration name to migrate up to
+   "
+  (with-db-connection-direct (connection)
+    (ensure-migration-table-impl *database-type* connection)
+    (loop for migration in *migrations*
+          for migration-name = (getf migration :migration-name)
+          do (let ((*database-type* (if (not-migrated-p connection migration-name t)
+                                        *database-type*
+                                        *dummy-connection*)))
+               (apply-migration connection migration)
+               (when (string= migration-name version)
+                 (return))))))
+
+(defun migrate-up-version (version)
+  "Apply specific migration version only.
+
+   @param version [string] Migration name to apply
+   @condition error Migration not found
+   "
+  (ensure-migration-table)
+  (setf *migrations* nil)
+  (load-migration-files)
+  (with-db-connection-direct (connection)
+    (ensure-migration-table-impl *database-type* connection)
+    (let ((migration (find-if #'(lambda (m)
+                                  (string= (getf m :migration-name) version))
+                              *migrations*)))
+      (if migration
+          (if (not-migrated-p connection version t)
+              (progn
+                (apply-migration connection migration)
+                (format t "Applied migration: ~A~%" version))
+              (format t "Migration already applied: ~A~%" version))
+          (error "Migration not found: ~A" version))))
+  (export-schema-file))
+
+(defun migrate-down-version (version)
+  "Rollback specific migration version only.
+
+   @param version [string] Migration name to rollback
+   @condition error Migration not found or down function not defined
+   "
+  (ensure-migration-table)
+  (setf *migrations* nil)
+  (load-migration-files)
+  (with-db-connection-direct (connection)
+    (ensure-migration-table-impl *database-type* connection)
+    (let ((migration (find-if #'(lambda (m)
+                                  (string= (getf m :migration-name) version))
+                              *migrations*)))
+      (if migration
+          (if (not-migrated-p connection version t)
+              (format t "Migration not yet applied: ~A~%" version)
+              (progn
+                (rollback-migration connection version)
+                (format t "Rolled back migration: ~A~%" version)))
+          (error "Migration not found: ~A" version))))
+  (export-schema-file))
+
+(defun db-rollback (&key (step 1))
+  "Rollback the last N database migrations.
+
+   @param step [integer] Number of migrations to rollback (default: 1)
+   "
+  (ensure-migration-table)
+  (setf *migrations* nil)
+  (load-migration-files)
+  (with-db-connection-direct (connection)
+    (loop for i from 1 to step
+          for migration-name = (get-last-migrated-name connection)
+          while migration-name
+          do (rollback-migration connection migration-name)))
+  (export-schema-file))
+
+(defun get-last-migrated-name (connection)
+  "Get the last applied migration name.
+
+   @param connection [dbi:<dbi-connection>] Database connection
+   @return [string] Last migration name
+   @return [nil] If no migrations have been applied
+   "
+  (let* ((query (dbi:prepare connection
+                             "select migration_name from migration order by created_at desc, migration_name desc limit 1"))
+         (result (dbi:execute query))
+         (row (dbi:fetch result)))
+    (when row
+      (getf row :|migration_name|))))
+
+(defun rollback-migration (connection migration-name)
+  "Rollback a specific migration.
+
+   @param connection [dbi:<dbi-connection>] Database connection
+   @param migration-name [string] Migration name to rollback
+   @condition error Migration not found or down function not defined
+   "
+  (let ((migration (find-if #'(lambda (m)
+                                (string= (getf m :migration-name) migration-name))
+                            *migrations*)))
+    (if migration
+        (let ((down-fn (getf migration :down)))
+          (when down-fn
+            (log.sql (format nil "Rolling back migration: ~A" migration-name))
+            (funcall down-fn connection)
+            (delete-migration connection migration-name)
+            (format t "Rolled back migration: ~A~%" migration-name)))
+        (error "Migration not found: ~A" migration-name))))
+
+(defun delete-migration (connection migration-name)
+  "Delete migration record from migration table.
+
+   @param connection [dbi:<dbi-connection>] Database connection
+   @param migration-name [string] Migration name to delete
+   "
+  (dbi:do-sql connection "delete from migration where migration_name = ?" (list migration-name)))
 
 (defun not-migrated-p (connection migration-name &optional verbose)
   (when verbose

--- a/test/data/0007-migration-kaizen-test/db/migrate/20250101-000000-create-users-table.lisp
+++ b/test/data/0007-migration-kaizen-test/db/migrate/20250101-000000-create-users-table.lisp
@@ -1,0 +1,11 @@
+(in-package #:clails-test/model/db/migration)
+
+(defmigration "20250101-000000-create-users-table"
+ (:up #'(lambda (conn)
+          (create-table conn :table "users"
+                             :columns '(("name" :type :string
+                                                :not-null T)
+                                        ("email" :type :string
+                                                 :not-null T))))
+  :down #'(lambda (conn)
+            (drop-table conn :table "users"))))

--- a/test/data/0007-migration-kaizen-test/db/migrate/20250102-000000-add-age-to-users.lisp
+++ b/test/data/0007-migration-kaizen-test/db/migrate/20250102-000000-add-age-to-users.lisp
@@ -1,0 +1,10 @@
+(in-package #:clails-test/model/db/migration)
+
+(defmigration "20250102-000000-add-age-to-users"
+ (:up #'(lambda (conn)
+          (add-column conn :table "users"
+                           :columns '(("age" :type :integer
+                                             :default-value 0))))
+  :down #'(lambda (conn)
+            (drop-column conn :table "users"
+                              :column "age"))))

--- a/test/data/0007-migration-kaizen-test/db/migrate/20250103-000000-create-posts-table.lisp
+++ b/test/data/0007-migration-kaizen-test/db/migrate/20250103-000000-create-posts-table.lisp
@@ -1,0 +1,15 @@
+(in-package #:clails-test/model/db/migration)
+
+(defmigration "20250103-000000-create-posts-table"
+ (:up #'(lambda (conn)
+          (create-table conn :table "posts"
+                             :columns '(("title" :type :string
+                                                :not-null T)
+                                        ("content" :type :text)
+                                        ("user_id" :type :integer
+                                                  :not-null T)))
+          (add-index conn :table "posts"
+                          :index "idx-user-id"
+                          :columns '("user_id")))
+  :down #'(lambda (conn)
+            (drop-table conn :table "posts"))))

--- a/test/data/0007-migration-kaizen-test/db/migrate/20250104-000000-add-published-to-posts.lisp
+++ b/test/data/0007-migration-kaizen-test/db/migrate/20250104-000000-add-published-to-posts.lisp
@@ -1,0 +1,10 @@
+(in-package #:clails-test/model/db/migration)
+
+(defmigration "20250104-000000-add-published-to-posts"
+ (:up #'(lambda (conn)
+          (add-column conn :table "posts"
+                           :columns '(("published" :type :boolean
+                                                   :default-value NIL))))
+  :down #'(lambda (conn)
+            (drop-column conn :table "posts"
+                              :column "published"))))

--- a/test/data/0007-migration-kaizen-test/db/migrate/20250105-000000-create-comments-table.lisp
+++ b/test/data/0007-migration-kaizen-test/db/migrate/20250105-000000-create-comments-table.lisp
@@ -1,0 +1,11 @@
+(in-package #:clails-test/model/db/migration)
+
+(defmigration "20250105-000000-create-comments-table"
+ (:up #'(lambda (conn)
+          (create-table conn :table "comments"
+                             :columns '(("post_id" :type :integer
+                                                   :not-null T)
+                                        ("comment" :type :text
+                                                   :not-null T))))
+  :down #'(lambda (conn)
+            (drop-table conn :table "comments"))))

--- a/test/model/migration.lisp
+++ b/test/model/migration.lisp
@@ -1,0 +1,477 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/migration
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:with-db-connection-direct)
+  (:import-from #:clails/model/migration
+                #:db-create
+                #:db-migrate
+                #:migrate-up-version
+                #:migrate-down-version
+                #:db-rollback
+                #:db-status))
+
+(defpackage #:clails-test/model/db/migration
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-column
+                #:add-index
+                #:drop-table
+                #:drop-column
+                #:drop-index))
+
+(in-package #:clails-test/model/migration)
+
+
+(setup
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0007" "/app/test/data/0007-migration-kaizen-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (db-create)
+  (clean-test-database)
+  (startup-connection-pool))
+
+(teardown
+  (clean-test-database)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (shutdown-connection-pool))
+
+
+;;; Helper functions
+
+(defun clean-test-database ()
+  "Drop all tables except migration table, then clean migration table."
+  (with-db-connection-direct (connection)
+    (let* ((tables-query (dbi:prepare connection "show tables"))
+           (tables-result (dbi:execute tables-query))
+           (tables (loop for row = (dbi:fetch tables-result)
+                        while row
+                        collect (getf row :|Tables_in_clails_test|))))
+      (dolist (table tables)
+        (unless (string= table "migration")
+          (dbi:do-sql connection (format nil "drop table if exists ~A" table))))
+      (dbi:do-sql connection "delete from migration"))))
+
+(defun get-migration-names (connection)
+  "Get all migration names from the migration table."
+  (let ((result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                    (dbi-cp:prepare connection "select migration_name from migration order by migration_name")
+                    '()))))
+    (mapcar #'(lambda (row) (getf row :|migration_name|)) result)))
+
+(defun table-exists-p (connection table-name)
+  "Check if a table exists in the database."
+  (let ((result (dbi-cp:fetch
+                  (dbi-cp:execute
+                    (dbi-cp:prepare connection "show tables like ?")
+                    (list table-name)))))
+    (not (null result))))
+
+(defun column-exists-p (connection table-name column-name)
+  "Check if a column exists in a table."
+  (let ((result (dbi-cp:fetch
+                  (dbi-cp:execute
+                    (dbi-cp:prepare connection
+                                    "select column_name from information_schema.columns where table_schema = database() and table_name = ? and column_name = ?")
+                    (list table-name column-name)))))
+    (not (null result))))
+
+
+;;; Test: db-migrate (all migrations)
+
+(deftest db-migrate-all-test
+  (testing "db-migrate applies all pending migrations"
+    (clean-test-database)
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 5 (length migrations))
+            "Should have 5 migrations applied")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should have users table migration")
+        (ok (member "20250102-000000-add-age-to-users" migrations :test #'string=)
+            "Should have add age migration")
+        (ok (member "20250103-000000-create-posts-table" migrations :test #'string=)
+            "Should have posts table migration")
+        (ok (member "20250104-000000-add-published-to-posts" migrations :test #'string=)
+            "Should have add published migration")
+        (ok (member "20250105-000000-create-comments-table" migrations :test #'string=)
+            "Should have comments table migration"))
+
+      (ok (table-exists-p connection "users")
+          "Users table should exist")
+      (ok (table-exists-p connection "posts")
+          "Posts table should exist")
+      (ok (table-exists-p connection "comments")
+          "Comments table should exist")
+      (ok (column-exists-p connection "users" "age")
+          "Users table should have age column")
+      (ok (column-exists-p connection "posts" "published")
+          "Posts table should have published column"))))
+
+
+;;; Test: db-migrate with version (migrate to specific version)
+
+(deftest db-migrate-to-version-test
+  (testing "db-migrate with version migrates up to specified version"
+    (clean-test-database)
+    (db-migrate :version "20250103-000000-create-posts-table")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 3 (length migrations))
+            "Should have 3 migrations applied")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should have users table migration")
+        (ok (member "20250102-000000-add-age-to-users" migrations :test #'string=)
+            "Should have add age migration")
+        (ok (member "20250103-000000-create-posts-table" migrations :test #'string=)
+            "Should have posts table migration")
+        (ok (not (member "20250104-000000-add-published-to-posts" migrations :test #'string=))
+            "Should not have add published migration")
+        (ok (not (member "20250105-000000-create-comments-table" migrations :test #'string=))
+            "Should not have comments table migration"))
+
+      (ok (table-exists-p connection "users")
+          "Users table should exist")
+      (ok (table-exists-p connection "posts")
+          "Posts table should exist")
+      (ok (not (table-exists-p connection "comments"))
+          "Comments table should not exist")
+      (ok (not (column-exists-p connection "posts" "published"))
+          "Posts table should not have published column yet"))))
+
+
+;;; Test: migrate-up-version (specific version only)
+
+(deftest migrate-up-version-test
+  (testing "migrate-up-version applies only the specified migration"
+    (clean-test-database)
+    ;; First, apply first three migrations to create posts table
+    (db-migrate :version "20250103-000000-create-posts-table")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 3 (length migrations))
+            "Should have 3 migrations applied initially")))
+
+    ;; Now apply only the 5th migration (skipping the 4th)
+    (migrate-up-version "20250105-000000-create-comments-table")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 4 (length migrations))
+            "Should have 4 migrations after migrate-up-version")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should still have users table migration")
+        (ok (member "20250102-000000-add-age-to-users" migrations :test #'string=)
+            "Should still have add age migration")
+        (ok (member "20250103-000000-create-posts-table" migrations :test #'string=)
+            "Should still have posts table migration")
+        (ok (not (member "20250104-000000-add-published-to-posts" migrations :test #'string=))
+            "Should not have add published migration (it was skipped)")
+        (ok (member "20250105-000000-create-comments-table" migrations :test #'string=)
+            "Should have comments table migration")))))
+
+
+;;; Test: migrate-up-version (already applied)
+
+(deftest migrate-up-version-already-applied-test
+  (testing "migrate-up-version on already applied migration shows message"
+    (clean-test-database)
+    (db-migrate :version "20250102-000000-add-age-to-users")
+
+    ;; Try to apply the same migration again
+    (ok (not (signals (migrate-up-version "20250102-000000-add-age-to-users")))
+        "Should not raise error when applying already applied migration")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 2 (length migrations))
+            "Should still have only 2 migrations")))))
+
+
+;;; Test: migrate-up-version (not found)
+
+(deftest migrate-up-version-not-found-test
+  (testing "migrate-up-version with non-existent version raises error"
+    (clean-test-database)
+    (ok (signals (migrate-up-version "20250199-000000-nonexistent") 'error)
+        "Should raise error for non-existent migration")))
+
+
+;;; Test: migrate-down-version (rollback specific version)
+
+(deftest migrate-down-version-test
+  (testing "migrate-down-version rolls back only the specified migration"
+    (clean-test-database)
+    ;; Apply all migrations
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations before rollback")
+      (ok (column-exists-p connection "posts" "published")
+          "Posts table should have published column before rollback"))
+
+    ;; Rollback only the 4th migration (add published to posts)
+    (migrate-down-version "20250104-000000-add-published-to-posts")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 4 (length migrations))
+            "Should have 4 migrations after migrate-down-version")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should still have users table migration")
+        (ok (member "20250102-000000-add-age-to-users" migrations :test #'string=)
+            "Should still have add age migration")
+        (ok (member "20250103-000000-create-posts-table" migrations :test #'string=)
+            "Should still have posts table migration")
+        (ok (not (member "20250104-000000-add-published-to-posts" migrations :test #'string=))
+            "Should not have add published migration after rollback")
+        (ok (member "20250105-000000-create-comments-table" migrations :test #'string=)
+            "Should still have comments table migration (later migration)"))
+
+      (ok (table-exists-p connection "posts")
+          "Posts table should still exist")
+      (ok (not (column-exists-p connection "posts" "published"))
+          "Posts table should not have published column after rollback")
+      (ok (table-exists-p connection "comments")
+          "Comments table should still exist (later migration not affected)"))))
+
+
+;;; Test: migrate-down-version (not yet applied)
+
+(deftest migrate-down-version-not-applied-test
+  (testing "migrate-down-version on not yet applied migration shows message"
+    (clean-test-database)
+    ;; Apply only first 2 migrations
+    (db-migrate :version "20250102-000000-add-age-to-users")
+
+    (with-db-connection-direct (connection)
+      (ok (= 2 (length (get-migration-names connection)))
+          "Should have 2 migrations before attempting rollback"))
+
+    ;; Try to rollback a migration that hasn't been applied
+    (ok (not (signals (migrate-down-version "20250103-000000-create-posts-table")))
+        "Should not raise error when rolling back unapplied migration")
+
+    (with-db-connection-direct (connection)
+      (ok (= 2 (length (get-migration-names connection)))
+          "Should still have 2 migrations (no change)"))))
+
+
+;;; Test: migrate-down-version (not found)
+
+(deftest migrate-down-version-not-found-test
+  (testing "migrate-down-version with non-existent version raises error"
+    (clean-test-database)
+    (db-migrate)
+    (ok (signals (migrate-down-version "20250199-000000-nonexistent") 'error)
+        "Should raise error for non-existent migration")))
+
+
+;;; Test: migrate-down-version (middle migration)
+
+(deftest migrate-down-version-middle-migration-test
+  (testing "migrate-down-version can rollback a middle migration"
+    (clean-test-database)
+    ;; Apply all migrations
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations initially")
+      (ok (column-exists-p connection "users" "age")
+          "Users table should have age column initially"))
+
+    ;; Rollback the 2nd migration (add age to users)
+    (migrate-down-version "20250102-000000-add-age-to-users")
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 4 (length migrations))
+            "Should have 4 migrations after rollback")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should still have users table migration")
+        (ok (not (member "20250102-000000-add-age-to-users" migrations :test #'string=))
+            "Should not have add age migration after rollback")
+        (ok (member "20250103-000000-create-posts-table" migrations :test #'string=)
+            "Should still have posts table migration")
+        (ok (member "20250104-000000-add-published-to-posts" migrations :test #'string=)
+            "Should still have add published migration")
+        (ok (member "20250105-000000-create-comments-table" migrations :test #'string=)
+            "Should still have comments table migration"))
+
+      (ok (table-exists-p connection "users")
+          "Users table should still exist")
+      (ok (not (column-exists-p connection "users" "age"))
+          "Users table should not have age column after rollback")
+      (ok (table-exists-p connection "posts")
+          "Posts table should still exist")
+      (ok (table-exists-p connection "comments")
+          "Comments table should still exist"))))
+
+
+;;; Test: db-rollback (single step)
+
+(deftest db-rollback-single-step-test
+  (testing "db-rollback rolls back the last migration"
+    (clean-test-database)
+    ;; Apply all migrations
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations before rollback")
+      (ok (table-exists-p connection "comments")
+          "Comments table should exist before rollback"))
+
+    ;; Rollback once
+    (db-rollback)
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 4 (length migrations))
+            "Should have 4 migrations after rollback")
+        (ok (not (member "20250105-000000-create-comments-table" migrations :test #'string=))
+            "Should not have comments table migration after rollback"))
+
+      (ok (not (table-exists-p connection "comments"))
+          "Comments table should not exist after rollback")
+      (ok (table-exists-p connection "posts")
+          "Posts table should still exist"))))
+
+
+;;; Test: db-rollback (multiple steps)
+
+(deftest db-rollback-multiple-steps-test
+  (testing "db-rollback with step parameter rolls back multiple migrations"
+    (clean-test-database)
+    ;; Apply all migrations
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations before rollback"))
+
+    ;; Rollback 3 steps
+    (db-rollback :step 3)
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 2 (length migrations))
+            "Should have 2 migrations after rollback")
+        (ok (member "20250101-000000-create-users-table" migrations :test #'string=)
+            "Should still have users table migration")
+        (ok (member "20250102-000000-add-age-to-users" migrations :test #'string=)
+            "Should still have add age migration")
+        (ok (not (member "20250103-000000-create-posts-table" migrations :test #'string=))
+            "Should not have posts table migration")
+        (ok (not (member "20250104-000000-add-published-to-posts" migrations :test #'string=))
+            "Should not have add published migration")
+        (ok (not (member "20250105-000000-create-comments-table" migrations :test #'string=))
+            "Should not have comments table migration"))
+
+      (ok (table-exists-p connection "users")
+          "Users table should still exist")
+      (ok (column-exists-p connection "users" "age")
+          "Users table should still have age column")
+      (ok (not (table-exists-p connection "posts"))
+          "Posts table should not exist")
+      (ok (not (table-exists-p connection "comments"))
+          "Comments table should not exist"))))
+
+
+;;; Test: db-rollback (rollback more than available)
+
+(deftest db-rollback-exceeds-available-test
+  (testing "db-rollback stops when no more migrations to rollback"
+    (clean-test-database)
+    ;; Apply only 2 migrations
+    (db-migrate :version "20250102-000000-add-age-to-users")
+
+    (with-db-connection-direct (connection)
+      (ok (= 2 (length (get-migration-names connection)))
+          "Should have 2 migrations before rollback"))
+
+    ;; Try to rollback 5 steps (more than available)
+    (db-rollback :step 5)
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 0 (length migrations))
+            "Should have 0 migrations after rolling back all")
+        (ok (not (table-exists-p connection "users"))
+            "Users table should not exist after complete rollback")))))
+
+
+;;; Test: Idempotent migrations
+
+(deftest idempotent-migration-test
+  (testing "Running db-migrate twice should be idempotent"
+    (clean-test-database)
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations after first run"))
+
+    ;; Run again
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should still have 5 migrations after second run")
+      (ok (table-exists-p connection "users")
+          "Users table should still exist")
+      (ok (table-exists-p connection "posts")
+          "Posts table should still exist")
+      (ok (table-exists-p connection "comments")
+          "Comments table should still exist"))))
+
+
+;;; Test: Rollback and re-migrate
+
+(deftest rollback-and-remigrate-test
+  (testing "Can rollback and then re-migrate"
+    (clean-test-database)
+    ;; Apply all migrations
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations initially"))
+
+    ;; Rollback 2 steps
+    (db-rollback :step 2)
+
+    (with-db-connection-direct (connection)
+      (ok (= 3 (length (get-migration-names connection)))
+          "Should have 3 migrations after rollback"))
+
+    ;; Re-migrate
+    (db-migrate)
+
+    (with-db-connection-direct (connection)
+      (ok (= 5 (length (get-migration-names connection)))
+          "Should have 5 migrations after re-migration")
+      (ok (table-exists-p connection "comments")
+          "Comments table should exist again"))))


### PR DESCRIPTION
# Implement db:migrate version control and db:rollback command

## Overview

Enhanced database migration functionality with more flexible version control and rollback capabilities.

## Changes

### New Features

1. **VERSION parameter support for `db:migrate`**
   - Allows migrating up to a specific version
   - Without parameters, runs all pending migrations as before

2. **`db:migrate:up` command implementation**
   - Executes a specific migration individually
   - VERSION parameter is required

3. **`db:migrate:down` command implementation**
   - Rolls back a specific migration individually
   - VERSION parameter is required

4. **`db:rollback` command implementation**
   - Rolls back the last applied migration
   - Supports multiple step rollback via `step` parameter

### Tests

- Added new test directory `test/data/0007-migration-kaizen-test`
- Added following test cases:
  - `db-migrate` with version parameter test
  - `migrate-up-version` individual migration execution test
  - `migrate-down-version` individual rollback test
  - `db-rollback` single step rollback test
  - `db-rollback` multiple steps rollback test
  - Behavior test when exceeding available rollback count
  - Migration idempotency test
  - Rollback and re-migration test

### Other Changes

- Added environment variable for new test data directory to CI workflow
- Added new test file to `clails-test.asd`
- Exported new command functions in `src/cmd.lisp`

## Usage Examples

```bash
# Migrate up to a specific version
$ clails db:migrate 20250103-000000-create-posts-table

# Run a specific migration
$ clails db:migrate:up 20250104-000000-add-published-to-posts

# Rollback a specific migration
$ clails db:migrate:down 20250104-000000-add-published-to-posts

# Rollback the last migration
$ clails db:rollback

# Rollback 3 steps
$ clails db:rollback 3
```

## Impact

- Existing `db:migrate` command maintains backward compatibility while being feature-enhanced
- New commands enable more granular migration control
- No impact on existing migration files

---

This change brings Ruby on Rails equivalent functionality of `db:migrate:up`, `db:migrate:down`, and `db:rollback` to clails.



