### PR TITLE
Add Swank Server Support for Development

### DIFF
--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -144,12 +144,16 @@ exec ros -Q -- $0 "$@"
   (format t "Options:~%")
   (format t "  -p, --port PORT           Port number (default: 5000)~%")
   (format t "  -b, --bind ADDRESS        Bind address (default: 127.0.0.1)~%")
+  (format t "  -s, --swank               Start swank server (default port: 4005)~%")
+  (format t "  --swank-port PORT         Specify swank server port~%")
   (format t "  -h, --help                Show this help message~%")
   (format t "~%")
   (format t "Examples:~%")
   (format t "  clails server~%")
   (format t "  clails server --port 8080~%")
-  (format t "  clails server --bind 0.0.0.0 --port 3000~%"))
+  (format t "  clails server --bind 0.0.0.0 --port 3000~%")
+  (format t "  clails server --swank                # Start swank on port 4005~%")
+  (format t "  clails server --swank --swank-port 4006  # Start swank on port 4006~%"))
 
 (defun help/stop ()
   (format t "Usage: clails stop [OPTIONS]~%~%")
@@ -492,6 +496,10 @@ exec ros -Q -- $0 "$@"
                                      :short-option "b"
                                      :long-option "bind"
                                      :consume t)
+                               (swank :short-option "s"
+                                      :long-option "swank")
+                               (swank-port :long-option "swank-port"
+                                           :consume t)
                                (help :short-option "h"
                                      :long-option "help"))
   (:help-function #'help/server)
@@ -499,7 +507,12 @@ exec ros -Q -- $0 "$@"
     (help/server)
     (uiop:quit 0))
   (load-project)
-  (clails/cmd:server :port port :bind bind))
+  (clails/cmd:server :port port
+                     :bind bind
+                     :swank-port (cond
+                                   (swank-port swank-port)
+                                   (swank "4005")
+                                   (t nil))))
 
 (define-command "stop" (&key (help :short-option "h"
                                    :long-option "help"))

--- a/template/project/base.asd.tmpl
+++ b/template/project/base.asd.tmpl
@@ -12,6 +12,7 @@
   :license ""
   :pathname "app"
   :depends-on ("clails"
+               "swank"
                "<%= (@ project-name ) %>/application-loader")
   :in-order-to ((test-op (test-op "<%= (@ project-name ) %>-test"))))
 


### PR DESCRIPTION
## Overview

Added an option to start a Swank server when running a clails application. This enables developers to use SLIME (Superior Lisp Interaction Mode for Emacs) to connect to the application for interactive debugging and code evaluation during development.

## Changes

### 1. Command-line Options

Added the following options to the `clails server` command:

- `-s, --swank`: Start the Swank server (default port: 4005)
- `--swank-port PORT`: Specify the port number for the Swank server

#### Usage Examples

```bash
# Start Swank server on default port 4005
clails server --swank

# Start Swank server on custom port 4006
clails server --swank --swank-port 4006

# Start web server with specified port and bind address along with Swank
clails server --port 8080 --bind 0.0.0.0 --swank
```

### 2. Server Function Extension

Extended the `clails/cmd:server` function with a `swank-port` parameter:

- When `swank-port` is specified, the Swank server is initialized on server startup
- The Swank server is managed by the `start-swank-server` function
- If `--swank-port` is not specified, the `--swank` flag automatically uses the default port 4005

### 3. Swank Server Management

New features added:

- `*swank-server*`: Parameter that holds the Swank server instance
- `start-swank-server`: Function to start the Swank server
- Added Swank server shutdown logic in the `stop-server` function

### 4. Project Template Update

Updated the generated project's `base.asd` to include `swank` as a dependency, making Swank automatically available.

## Technical Details

- Swank server startup and shutdown use the existing error handling mechanism
- Port number parsing errors are caught and reported appropriately
- Swank server is stopped simultaneously when the main server stops

## Benefits

- **Interactive Debugging**: Evaluate application code directly from SLIME
- **Hot Reload**: Changes are reflected immediately
- **Improved Development Experience**: Provides an integrated development environment with Emacs

## Important Notes

- Swank server is recommended for development environments only
- Not started by default; the `--swank` option must be explicitly specified
- Pay attention to firewall settings to ensure security

