### PR TITLE
Add Swank Server Bind Address Configuration

### DIFF
--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -144,16 +144,17 @@ exec ros -Q -- $0 "$@"
   (format t "Options:~%")
   (format t "  -p, --port PORT           Port number (default: 5000)~%")
   (format t "  -b, --bind ADDRESS        Bind address (default: 127.0.0.1)~%")
-  (format t "  -s, --swank               Start swank server (default port: 4005)~%")
-  (format t "  --swank-port PORT         Specify swank server port~%")
+  (format t "  -s, --swank               Start swank server (default: 127.0.0.1:4005)~%")
+  (format t "  --swank-address ADDRES    Specify swank server bind address (default: 127.0.0.1)~%")
+  (format t "  --swank-port PORT         Specify swank server port (default: 4005)~%")
   (format t "  -h, --help                Show this help message~%")
   (format t "~%")
   (format t "Examples:~%")
   (format t "  clails server~%")
   (format t "  clails server --port 8080~%")
   (format t "  clails server --bind 0.0.0.0 --port 3000~%")
-  (format t "  clails server --swank                # Start swank on port 4005~%")
-  (format t "  clails server --swank --swank-port 4006  # Start swank on port 4006~%"))
+  (format t "  clails server --swank                                            # Start swank on 127.0.0.1:4005~%")
+  (format t "  clails server --swank --swank-address 0.0.0.0 --swank-port 4006  # Start swank on 0.0.0.0:4006~%"))
 
 (defun help/stop ()
   (format t "Usage: clails stop [OPTIONS]~%~%")
@@ -498,6 +499,9 @@ exec ros -Q -- $0 "$@"
                                      :consume t)
                                (swank :short-option "s"
                                       :long-option "swank")
+                               (swank-address :default "127.0.0.1"
+                                              :long-option "swank-address"
+                                              :consume t)
                                (swank-port :long-option "swank-port"
                                            :consume t)
                                (help :short-option "h"
@@ -512,7 +516,8 @@ exec ros -Q -- $0 "$@"
                      :swank-port (cond
                                    (swank-port swank-port)
                                    (swank "4005")
-                                   (t nil))))
+                                   (t nil))
+                     :swank-address swank-address))
 
 (define-command "stop" (&key (help :short-option "h"
                                    :long-option "help"))


### PR DESCRIPTION
## Overview

Added support for configuring the bind address of the Swank server. This allows developers to specify which network interface the Swank server should listen on, enabling remote debugging scenarios and flexible development setups.

## Changes

### 1. Command-line Options

Extended the `clails server` command with a new option:

- `--swank-address ADDRESS`: Specify the bind address for the Swank server (default: 127.0.0.1)

The existing options remain:
- `-s, --swank`: Start the Swank server
- `--swank-port PORT`: Specify the port number for the Swank server

#### Usage Examples

```bash
# Start Swank server on default address 127.0.0.1:4005
CL_SOURCE_REGISTRY=$PWD clails server --swank

# Start Swank server on all interfaces
CL_SOURCE_REGISTRY=$PWD clails server --swank --swank-address 0.0.0.0 --swank-port 4005

# Start Swank server on specific address with custom port
CL_SOURCE_REGISTRY=$PWD clails server --swank --swank-address 192.168.1.100 --swank-port 4006

# Start web server and Swank server with different bind addresses
CL_SOURCE_REGISTRY=$PWD clails server --port 8080 --bind 0.0.0.0 --swank --swank-address 127.0.0.1
```

### 2. Roswell Script Updates

Updated `roswell/clails.ros`:

- Added `--swank-address` parameter definition with default value `127.0.0.1`
- Updated help message to show the complete default address and port format
- Updated command examples to demonstrate the new bind address functionality
- Pass `swank-address` parameter to the server initialization

### 3. Server Function Extension

Extended the `clails/cmd:server` function:

- Added `swank-address` parameter (default: "127.0.0.1")
- Pass the address to `start-swank-server` function

### 4. Swank Server Initialization

Updated `start-swank-server` function in `src/cmd.lisp`:

- Now accepts both `address` and `port` parameters
- Sets `swank::*loopback-interface*` to the specified address before server creation
- Adds `:style :spawn` parameter to Swank server creation for better multi-connection handling
- Updated output message to display the full address:port combination

## Technical Details

- The `swank::*loopback-interface*` variable is set before Swank server creation to control the bind address
- The `:style :spawn` option improves Swank's ability to handle multiple concurrent connections
- Default address remains `127.0.0.1` for security (localhost only)
- Address validation is delegated to Swank library

## Benefits

- **Remote Debugging**: Connect to SLIME from different machines by specifying a non-localhost address
- **Flexible Development Setups**: Support various network configurations
- **Backward Compatible**: Default behavior remains unchanged (127.0.0.1:4005)
- **Security**: Developers can explicitly control which addresses accept connections

## Important Notes

- Swank server with non-localhost addresses should only be used in secure networks
- The default bind address (127.0.0.1) provides security by limiting local access only
- When binding to 0.0.0.0, the server will listen on all available network interfaces
- Firewall configuration must be properly managed when using non-localhost addresses

