### PR TITLE
Fix View Package Resolution to Use *project-name*

### DIFF
--- a/src/controller/base-controller.lisp
+++ b/src/controller/base-controller.lisp
@@ -7,7 +7,8 @@
                 #:404/not-found)
   (:import-from #:clails/environment
                 #:*routing-tables*
-                #:*project-dir*)
+                #:*project-dir*
+                #:*project-name*)
   (:import-from #:clails/logger
                 #:log.web-access
                 #:log-package.trace
@@ -187,29 +188,25 @@
 
 
 (defun resolve-view-package (viewname)
-  "Resolve package name from view file path.
+  "Resolve package name from view file path using central *project-name*.
 
    Converts view path to package name following the convention:
    - \"index.html\" -> :{project}/views/package
    - \"todo/show.html\" -> :{project}/views/todo/package
    - \"admin/user/list.html\" -> :{project}/views/admin/user/package
 
+   This implementation uses clails/environment:*project-name* instead of inferring
+   the project name from *project-dir* to avoid failures when the directory path changes.
+
    @param viewname [string] View file path relative to app/views/
    @return [keyword] Package name as keyword
    "
-  (let* ((project-name (get-project-name))
+  (let* ((project-name *project-name*)
          (path-parts (split-view-path viewname)))
     (make-keyword
       (if path-parts
           (format nil "~A/views/~{~A~^/~}/package" project-name path-parts)
           (format nil "~A/views/package" project-name)))))
-
-(defun get-project-name ()
-  "Get current project name from *project-dir*.
-
-   @return [string] Project name
-   "
-  (car (last (pathname-directory *project-dir*))))
 
 (defun split-view-path (viewname)
   "Split view path and extract directory parts (excluding filename).

--- a/test/controller/base-controller.lisp
+++ b/test/controller/base-controller.lisp
@@ -84,10 +84,6 @@
 
 
 (deftest view-package-resolution-test
-  (testing "get-project-name extracts project name from *project-dir*"
-    (let ((clails/environment:*project-dir* #P"/home/user/projects/testapp/"))
-      (ok (string= (clails/controller/base-controller::get-project-name) "testapp"))))
-
   (testing "split-view-path extracts directory parts"
     (ok (equal (clails/controller/base-controller::split-view-path "index.html") nil))
     (ok (equal (clails/controller/base-controller::split-view-path "todo/show.html") '("todo")))
@@ -100,7 +96,7 @@
             :testapp/views/todo/package)))
 
   (testing "resolve-view-package resolves package name from view path"
-    (let ((clails/environment:*project-dir* #P"/home/user/projects/testapp/"))
+    (let ((clails/environment:*project-name* "testapp"))
       (ok (eq (clails/controller/base-controller::resolve-view-package "index.html")
               :testapp/views/package))
       (ok (eq (clails/controller/base-controller::resolve-view-package "todo/show.html")
@@ -112,6 +108,7 @@
 (deftest set-view-with-package-test
   (testing "set-view sets view-package slot"
     (let* ((clails/environment:*project-dir* #P"/home/user/projects/testapp/")
+           (clails/environment:*project-name* "testapp")
            (controller (make-instance '<web-controller>)))
       (set-view controller "todo/show.html")
       (ok (eq (view-package controller) :testapp/views/todo/package))


### PR DESCRIPTION
## Problem

View package resolution failed in Docker/CI environments where the project directory path differs from the original path. The `resolve-view-package` function inferred the project name from `*project-dir*` instead of using the explicit `*project-name*` variable.

## Solution

- Use `clails/environment:*project-name*` directly in `resolve-view-package`
- Remove unused `get-project-name` function
- Update tests to reflect the change

## Changes

- `src/controller/base-controller.lisp`: Replace `(get-project-name)` with `*project-name*`
- `test/controller/base-controller.lisp`: Update tests to use `*project-name*`

Closes #85