### PR TITLE
Add Docker development environment support for project generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /qlot
 COPY ./qlfile /qlot
 RUN echo 'local clails /app' >> /qlot/qlfile
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ros run -e "(ql:quickload :swank)" -e "(setf swank::*loopback-interface* \"0.0.0.0\")" -e "(swank:create-server :port 4005 :dont-close t :style :spawn)"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./:/app
     ports:
-      - 4005:4005
+      - "4005:4005"
     tty: true
     networks:
       - clails_dev_nw
@@ -35,4 +35,4 @@ services:
       - clails_dev_nw
 networks:
   clails_dev_nw:
-    external: true
+    driver: bridge

--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -167,8 +167,13 @@ exec ros -Q -- $0 "$@"
 
 ;; Utility functions
 (defun load-project ()
-  (push (uiop/os:getcwd) ql:*local-project-directories*)
-  (load "clails.boot"))
+  (let* ((clails-home (uiop:getenv "CLAILS_HOME"))
+         (project-dir (if clails-home
+                          (uiop:ensure-directory-pathname clails-home)
+                          (uiop/os:getcwd)))
+         (boot-file (merge-pathnames "clails.boot" project-dir)))
+    (push project-dir ql:*local-project-directories*)
+    (load boot-file)))
 
 ;; Command definition macro
 (defmacro define-command (name params &body body)

--- a/src/project/project.lisp
+++ b/src/project/project.lisp
@@ -22,7 +22,8 @@
     "test"
     "test/models"
     "test/controllers"
-    "test/views")
+    "test/views"
+    "docker")
   "List of directories to create in a new Clails project.")
 
 (defun create-project (project-name project-dir database)
@@ -205,7 +206,43 @@
                                project-name
                                project-dir
                                database
-                               (read-template "test/sample.lisp.tmpl"))))
+                               (read-template "test/sample.lisp.tmpl"))
+
+    ;; docker files
+    (create-file-with-template "docker/Dockerfile.dev"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "docker/Dockerfile.dev.tmpl"))
+    (create-file-with-template "docker/docker-compose.dev.yml"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "docker/docker-compose.dev.yml.tmpl"))
+    (create-file-with-template "docker/dev.env"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "docker/dev.env.tmpl"))
+    (create-file-with-template "docker/run-dev.sh"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "docker/run-dev.sh.tmpl"))
+
+    ;; Makefile
+    (create-file-with-template "Makefile"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "Makefile.tmpl"))
+
+    ;; README
+    (create-file-with-template "README.md"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "README.md.tmpl"))))
 
 
 (defun copy-asset-files (project-dir)

--- a/template/project/Makefile.tmpl
+++ b/template/project/Makefile.tmpl
@@ -1,0 +1,44 @@
+.PHONY: build
+build:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env build
+
+.PHONY: rebuild
+rebuild:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env build --no-cache
+
+.PHONY: up down
+up:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env up -d
+
+down:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env down
+
+.PHONY: console
+console:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env run --rm -it --entrypoint /bin/bash <%= (@ project-name ) %>-app
+
+.PHONY: logs<% (when (eq (@ database) :mysql) %> logs.mysql<% ) %><% (when (eq (@ database) :postgresql) %> logs.postgresql<% ) %>
+logs:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env logs -f <%= (@ project-name ) %>-app
+<% (when (eq (@ database) :mysql) %>
+logs.mysql:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env logs -f mysql-dev
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+logs.postgresql:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env logs -f postgresql-dev
+<% ) %>
+
+.PHONY: db.create db.migrate db.rollback db.seed
+db.create:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env run --rm --entrypoint clails <%= (@ project-name ) %>-app db:create
+
+db.migrate:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env run --rm --entrypoint clails <%= (@ project-name ) %>-app db:migrate
+
+db.rollback:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env run --rm --entrypoint clails <%= (@ project-name ) %>-app db:rollback
+
+db.seed:
+	docker compose -f docker/docker-compose.dev.yml --env-file docker/dev.env run --rm --entrypoint clails <%= (@ project-name ) %>-app db:seed
+

--- a/template/project/README.md.tmpl
+++ b/template/project/README.md.tmpl
@@ -1,0 +1,190 @@
+# <%= (@ project-name ) %>
+
+A web application built with [clails](https://github.com/tamurashingo/clails) framework.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Getting Started
+
+### 1. Build Docker Image
+
+```bash
+make build
+```
+
+### 2. Start Development Environment
+
+```bash
+make up
+```
+
+This will start:
+- Application server on http://localhost:5000
+- Swank server on localhost:4005 (for REPL development)
+<% (when (eq (@ database) :mysql) %>
+- MySQL database on localhost:3306
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+- PostgreSQL database on localhost:5432
+<% ) %>
+
+### 3. Setup Database
+
+Create the database:
+
+```bash
+make db.create
+```
+
+Run migrations:
+
+```bash
+make db.migrate
+```
+
+Seed the database (optional):
+
+```bash
+make db.seed
+```
+
+### 4. Access the Application
+
+Open your browser and navigate to:
+```
+http://localhost:5000
+```
+
+## Development
+
+### REPL Development with Swank
+
+Connect to the Swank server from your editor (Emacs/SLIME, Vim/Slimv, etc.):
+
+- Host: `localhost`
+- Port: `4005`
+
+### Available Make Commands
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Build Docker image |
+| `make rebuild` | Rebuild Docker image without cache |
+| `make up` | Start containers in detached mode |
+| `make down` | Stop and remove containers |
+| `make console` | Open bash shell in the application container |
+| `make logs` | View application logs |
+<% (when (eq (@ database) :mysql) %>
+| `make logs.mysql` | View MySQL logs |
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+| `make logs.postgresql` | View PostgreSQL logs |
+<% ) %>
+| `make db.create` | Create database |
+| `make db.migrate` | Run pending migrations |
+| `make db.rollback` | Rollback the last migration |
+| `make db.seed` | Load seed data |
+
+### Project Structure
+
+```
+.
+├── app/
+│   ├── config/         # Configuration files
+│   ├── controllers/    # Controller files
+│   ├── models/         # Model files
+│   └── views/          # View templates
+├── db/
+│   ├── migrate/        # Database migration files
+│   └── seeds.lisp      # Seed data
+├── docker/
+│   ├── Dockerfile.dev           # Development Dockerfile
+│   ├── docker-compose.dev.yml   # Docker Compose configuration
+│   ├── dev.env                  # Environment variables
+│   └── run-dev.sh               # Application startup script
+├── public/             # Static assets
+├── test/               # Test files
+└── Makefile            # Make commands
+```
+
+## Database Configuration
+
+<% (when (eq (@ database) :mysql) %>
+**MySQL Configuration**
+
+Default settings:
+- Host: `mysql-dev` (inside Docker), `localhost` (from host)
+- Port: `3306`
+- Username: `<%= (@ project-name ) %>`
+- Password: `password`
+- Database: `<%= (@ project-name ) %>_development`
+
+You can override these settings by editing `docker/dev.env`.
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+**PostgreSQL Configuration**
+
+Default settings:
+- Host: `postgresql-dev` (inside Docker), `localhost` (from host)
+- Port: `5432`
+- Username: `<%= (@ project-name ) %>`
+- Password: `password`
+- Database: `<%= (@ project-name ) %>_development`
+
+You can override these settings by editing `docker/dev.env`.
+<% ) %>
+<% (when (eq (@ database) :sqlite3) %>
+**SQLite3 Configuration**
+
+Database file location: `tmp/<%= (@ project-name ) %>-develop.sqlite3`
+<% ) %>
+
+## Troubleshooting
+
+### Container won't start
+
+Check logs:
+```bash
+make logs
+```
+
+### Database connection issues
+<% (when (or (eq (@ database) :mysql) (eq (@ database) :postgresql)) %>
+
+Make sure the database container is running:
+```bash
+docker compose -f docker/docker-compose.dev.yml ps
+```
+
+Check database logs:
+<% (when (eq (@ database) :mysql) %>
+```bash
+make logs.mysql
+```
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+```bash
+make logs.postgresql
+```
+<% ) %>
+<% ) %>
+
+### Reset everything
+
+Stop containers and remove volumes:
+```bash
+make down
+<% (when (eq (@ database) :mysql) %>
+docker volume rm <%= (@ project-name ) %>-mysql-data
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+docker volume rm <%= (@ project-name ) %>-postgresql-data
+<% ) %>
+```
+
+## License
+
+[Add your license here]

--- a/template/project/app/config/database-mysql.lisp.tmpl
+++ b/template/project/app/config/database-mysql.lisp.tmpl
@@ -14,15 +14,15 @@
 (defun initialize-database-config ()
   (setf clails/environment:*database-config*
         `(:database :mysql
-          :develop (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_develop")
+          :develop (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_development")
                     :host ,(env-or-default "CLAILS_DB_HOST" "localhost")
                     :port ,(env-or-default "CLAILS_DB_PORT" "3306")
-                    :username ,(env-or-default "CLAILS_DB_USERNAME" "root")
+                    :username ,(env-or-default "CLAILS_DB_USERNAME" "<%= (@ project-name ) %>")
                     :password ,(env-or-default "CLAILS_DB_PASSWORD" "password"))
           :test (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_test")
                  :host ,(env-or-default "CLAILS_DB_HOST" "localhost")
                  :port ,(env-or-default "CLAILS_DB_PORT" "3306")
-                 :username ,(env-or-default "CLAILS_DB_USERNAME" "root")
+                 :username ,(env-or-default "CLAILS_DB_USERNAME" "<%= (@ project-name ) %>")
                  :password ,(env-or-default "CLAILS_DB_PASSWORD" "password"))
           :production (:database-name ,(env "CLAILS_DB_NAME")
                        :host ,(env "CLAILS_DB_HOST")

--- a/template/project/app/config/database-postgresql.lisp.tmpl
+++ b/template/project/app/config/database-postgresql.lisp.tmpl
@@ -13,16 +13,16 @@
 
 (defun initialize-database-config ()
   (setf clails/environment:*database-config*
-        `(:database :mysql
-          :develop (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_develop")
+        `(:database :postgresql
+          :develop (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_development")
                     :host ,(env-or-default "CLAILS_DB_HOST" "localhost")
                     :port ,(env-or-default "CLAILS_DB_PORT" "5432")
-                    :username ,(env-or-default "CLAILS_DB_USERNAME" "clails")
+                    :username ,(env-or-default "CLAILS_DB_USERNAME" "<%= (@ project-name ) %>")
                     :password ,(env-or-default "CLAILS_DB_PASSWORD" "password"))
           :test (:database-name ,(env-or-default "CLAILS_DB_NAME" "<%= (@ project-name ) %>_test")
                  :host ,(env-or-default "CLAILS_DB_HOST" "localhost")
                  :port ,(env-or-default "CLAILS_DB_PORT" "5432")
-                 :username ,(env-or-default "CLAILS_DB_USERNAME" "clails")
+                 :username ,(env-or-default "CLAILS_DB_USERNAME" "<%= (@ project-name ) %>")
                  :password ,(env-or-default "CLAILS_DB_PASSWORD" "password"))
           :production (:database-name ,(env "CLAILS_DB_NAME")
                        :host ,(env "CLAILS_DB_HOST")

--- a/template/project/app/config/environment.lisp.tmpl.bak
+++ b/template/project/app/config/environment.lisp.tmpl.bak
@@ -1,0 +1,29 @@
+; -*- mode: lisp -*-
+(in-package #:cl-user)
+(defpackage #:<%= (@ project-name ) %>/config/environment
+  (:use #:cl)
+  (:import-from #:clails/environment
+                #:*project-environment*
+                #:*routing-tables*)
+  (:import-from #:clails/middleware
+                #:add-middleware-before
+                #:add-middleware-after))
+
+(in-package #:<%= (@ project-name ) %>/config/environment)
+
+;; project name
+(setf clails/environment:*project-name* "<%= (@ project-name ) %>")
+
+;; project environment
+(setf clails/environment:*project-environment* :develop)
+
+(setf *routing-tables*
+  '((:path "/"
+     :controller "<%= (@ project-name )%>/controllers/application-controller:<application-controller>")))
+
+
+;; startup hooks
+(push "<%= (@ project-name) %>/config/logger/initialize-logger" clails/environment:*startup-hooks*)
+
+;; shutdown hooks
+(push "<%= (@ project-name) %>/config/logger/finalize-logger" clails/environment:*shutdown-hooks*)

--- a/template/project/clails.boot.tmpl
+++ b/template/project/clails.boot.tmpl
@@ -1,10 +1,14 @@
 ; -*- mode: lisp -*-
 ;;;; boot from clails cli
 
-(push (uiop/os:getcwd) asdf:*central-registry*)
-(asdf:load-system :<%= (@ project-name ) %>)
-(setf clails/environment:*project-dir* (uiop/os:getcwd))
-(setf clails/environment:*migration-base-dir* clails/environment:*project-dir*)
+(let* ((clails-home (uiop:getenv "CLAILS_HOME"))
+       (project-dir (if clails-home
+                        (uiop:ensure-directory-pathname clails-home)
+                        (uiop/os:getcwd))))
+  (push project-dir asdf:*central-registry*)
+  (asdf:load-system :<%= (@ project-name ) %>)
+  (setf clails/environment:*project-dir* project-dir)
+  (setf clails/environment:*migration-base-dir* clails/environment:*project-dir*))
 
 (let ((envname (uiop:getenv "CLAILS_ENV")))
   (when envname

--- a/template/project/docker/Dockerfile.dev.tmpl
+++ b/template/project/docker/Dockerfile.dev.tmpl
@@ -1,0 +1,41 @@
+# <%= (@ project-name ) %> development Dockerfile
+FROM fukamachi/sbcl
+
+ENV BIND_ADDRESS="127.0.0.1"
+ENV PORT="5000"
+ENV SWANK_ADDRESS="127.0.0.1"
+ENV SWANK_PORT="4005"
+
+
+RUN apt-get update && apt-get install -y \
+  default-libmysqlclient-dev \
+  libpq-dev \
+  libsqlite3-dev \
+  default-mysql-client \
+  postgresql-client \
+  sqlite3
+
+RUN ros run -e "(ql-dist:install-dist \"http://dist.shirakumo.org/shirakumo.txt\" :prompt nil)"
+RUN ros install qlot
+
+ENV PATH=${PATH}:/root/.roswell/bin:/qlot/.qlot/bin
+
+RUN mkdir /qlot
+RUN echo 'github fukamachi/cl-dbi' > /qlot/qlfile
+RUN echo 'github tamurashingo/cl-dbi-connection-pool' >> /qlot/qlfile
+RUN echo 'github tamurashingo/getcmd' >> /qlot/qlfile
+# use clails develop version
+RUN cd /qlot && qlot install &&  qlot exec ros install tamurashingo/clails/develop
+
+ENV CLAILS_CONF_DIR=/qlot
+
+COPY docker/run-dev.sh /qlot
+RUN chmod +x /qlot/run-dev.sh
+
+RUN mkdir -p /app
+WORKDIR /app
+
+# load libraries
+RUN clails
+
+ENTRYPOINT /qlot/run-dev.sh

--- a/template/project/docker/dev.env.tmpl
+++ b/template/project/docker/dev.env.tmpl
@@ -1,0 +1,20 @@
+# <%= (@ project-name ) %> dev environment variables
+CLAILS_HOME=/app
+BIND_ADDRESS=0.0.0.0
+PORT=5000
+SWANK_ADDRESS=0.0.0.0
+SWANK_PORT=4005
+
+# Database configuration
+<% (when (eq (@ database) :mysql) %>
+CLAILS_DB_HOST=mysql-dev
+CLAILS_DB_PORT=3306
+CLAILS_DB_USERNAME=<%= (@ project-name ) %>
+CLAILS_DB_PASSWORD=password
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+CLAILS_DB_HOST=postgresql-dev
+CLAILS_DB_PORT=5432
+CLAILS_DB_USERNAME=<%= (@ project-name ) %>
+CLAILS_DB_PASSWORD=password
+<% ) %>

--- a/template/project/docker/docker-compose.dev.yml.tmpl
+++ b/template/project/docker/docker-compose.dev.yml.tmpl
@@ -1,0 +1,84 @@
+services:
+  <%= (@ project-name ) %>-app:
+    image: <%= (@ project-name ) %>_dev
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.dev
+    container_name: <%= (@ project-name ) %>_dev_app
+    volumes:
+      - ../:/app
+    ports:
+      - ${PORT}:${PORT}
+      - ${SWANK_PORT}:${SWANK_PORT}
+    tty: true
+    command: ["/qlot/run-dev.sh"]
+    environment:
+      CLAILS_HOME: "/app"
+      BIND_ADDRESS: "${BIND_ADDRESS}"
+      PORT: "${PORT}"
+      SWANK_ADDRESS: "${SWANK_ADDRESS}"
+      SWANK_PORT: "${SWANK_PORT}"
+<% (when (eq (@ database) :mysql) %>
+      CLAILS_DB_HOST: "${CLAILS_DB_HOST}"
+      CLAILS_DB_PORT: "${CLAILS_DB_PORT}"
+      CLAILS_DB_USERNAME: "${CLAILS_DB_USERNAME}"
+      CLAILS_DB_PASSWORD: "${CLAILS_DB_PASSWORD}"
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+      CLAILS_DB_HOST: "${CLAILS_DB_HOST}"
+      CLAILS_DB_PORT: "${CLAILS_DB_PORT}"
+      CLAILS_DB_USERNAME: "${CLAILS_DB_USERNAME}"
+      CLAILS_DB_PASSWORD: "${CLAILS_DB_PASSWORD}"
+<% ) %>
+    networks:
+      - <%= (@ project-name ) %>-net
+<% (when (eq (@ database) :mysql) %>
+    depends_on:
+      - mysql-dev
+
+  mysql-dev:
+    image: mysql:8.0
+    container_name: <%= (@ project-name ) %>_dev_mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: <%= (@ project-name ) %>
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: <%= (@ project-name ) %>_development
+    ports:
+      - 3306:3306
+    volumes:
+      - <%= (@ project-name ) %>-mysql-data:/var/lib/mysql
+    networks:
+      - <%= (@ project-name ) %>-net
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+    depends_on:
+      - postgresql-dev
+
+  postgresql-dev:
+    image: postgres:16.3
+    container_name: <%= (@ project-name ) %>_dev_postgresql
+    environment:
+      POSTGRES_USER: <%= (@ project-name ) %>
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: <%= (@ project-name ) %>_development
+    ports:
+      - 5432:5432
+    volumes:
+      - <%= (@ project-name ) %>-postgresql-data:/var/lib/postgresql/data
+    networks:
+      - <%= (@ project-name ) %>-net
+<% ) %>
+
+networks:
+  <%= (@ project-name ) %>-net:
+    driver: bridge
+
+<% (when (eq (@ database) :mysql) %>
+volumes:
+  <%= (@ project-name ) %>-mysql-data:
+<% ) %>
+<% (when (eq (@ database) :postgresql) %>
+volumes:
+  <%= (@ project-name ) %>-postgresql-data:
+<% ) %>

--- a/template/project/docker/run-dev.sh.tmpl
+++ b/template/project/docker/run-dev.sh.tmpl
@@ -1,0 +1,5 @@
+#!/bin/sh
+# <%= (@ project-name ) %> dev run script
+
+exec clails server -b ${BIND_ADDRESS} --port ${PORT} --swank --swank-address ${SWANK_ADDRESS} --swank-port ${SWANK_PORT}
+


### PR DESCRIPTION
Implements issue #88 to provide complete Docker development environment auto-generation when creating projects with `clails new`.

close: #88

### Changes
- Auto-generates Docker configuration files (Dockerfile.dev, docker-compose.dev.yml, dev.env, run-dev.sh, Makefile)
- Introduces `CLAILS_HOME` environment variable to support containerized workflows where qlot changes working directory
- Supports all database types (SQLite3, MySQL, PostgreSQL) with appropriate container configurations
- Enables REPL development via Swank server (port 4005) in Docker environment

### Benefits
- Developers can start working without installing Common Lisp or databases locally
- Simplified onboarding with `make build && make up && make db.migrate`
- Consistent development environment across team members

