### PR TITLE
Pessimistic Lock Implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         CLAILS_MIGRATION_DIR_0005: ${{ github.workspace }}/test/data/0005-default-value-test
         CLAILS_MIGRATION_DIR_0006: ${{ github.workspace }}/test/data/0006-transaction-test
         CLAILS_MIGRATION_DIR_0007: ${{ github.workspace }}/test/data/0007-migration-kaizen-test
+        CLAILS_MIGRATION_DIR_0008: ${{ github.workspace }}/test/data/0008-pessimistic-lock-test
         CLAILS_SQLITE3_DATABASE: ${{ github.workspace }}
         CLAILS_MYSQL_DATABASE: clails_test
         CLAILS_MYSQL_USERNAME: root

--- a/clails-test.asd
+++ b/clails-test.asd
@@ -29,6 +29,9 @@
                #:clails-test/model/transaction/transaction-sqlite3
                #:clails-test/model/transaction/transaction-mysql
                #:clails-test/model/transaction/transaction-postgresql
+               #:clails-test/model/pessimistic-lock/lock-sqlite3
+               #:clails-test/model/pessimistic-lock/lock-mysql
+               #:clails-test/model/pessimistic-lock/lock-postgresql
                #:clails-test/logger/registry
                #:clails-test/logger/purpose-specific
                #:clails-test/logger/file-appender

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -11,6 +11,16 @@
            #:*routing-tables*
            #:*startup-hooks*
            #:*shutdown-hooks*
+           #:*default-lock-mode*
+           #:*sqlite3-busy-timeout*
+           #:*sqlite3-lock-retry-count*
+           #:*sqlite3-transaction-mode*
+           #:*sqlite3-lock-module-loaded*
+           #:<database-type>
+           #:<database-type-mysql>
+           #:<database-type-postgresql>
+           #:<database-type-sqlite3>
+           #:<database-type-dummy>
            #:set-environment))
 (in-package #:clails/environment)
 
@@ -68,13 +78,63 @@
 (defparameter *shutdown-hooks*
   '("clails/model/connection:shutdown-connection-pool"))
 
+(defparameter *default-lock-mode* :for-update
+  "Default lock mode for with-locked-transaction macro.
+
+   Possible values:
+   - :for-update        - Exclusive lock (default) - PostgreSQL/MySQL
+   - :for-share         - Shared lock - PostgreSQL/MySQL
+   - :for-no-key-update - PostgreSQL only
+   - :for-key-share     - PostgreSQL only
+   - :immediate         - SQLite3 only (BEGIN IMMEDIATE)
+   - :exclusive         - SQLite3 only (BEGIN EXCLUSIVE)
+
+   This can be overridden in <project>/app/config/environment.lisp")
+
+(defparameter *sqlite3-busy-timeout* 50
+  "SQLite3 busy timeout in milliseconds.
+
+   When SQLite3 encounters a locked database, it will wait up to this
+   many milliseconds before returning SQLITE_BUSY error.
+   Default is 50ms.
+
+   This can be overridden in <project>/app/config/environment.lisp")
+
+(defparameter *sqlite3-lock-retry-count* 3
+  "Number of retry attempts for SQLite3 locked database errors.
+
+   When BEGIN IMMEDIATE fails due to database lock, the transaction
+   will be retried up to this many times with exponential backoff.
+   Default is 3 retries.
+
+   This can be overridden in <project>/app/config/environment.lisp")
+
+(defparameter *sqlite3-transaction-mode* nil
+  "SQLite3 transaction mode for the current dynamic context.
+
+   This is a special variable used to pass the transaction mode
+   to the begin-transaction method override in sqlite3-lock module.
+
+   Possible values:
+   - nil          - Normal transaction (BEGIN TRANSACTION)
+   - :immediate   - Immediate lock (BEGIN IMMEDIATE)
+   - :exclusive   - Exclusive lock (BEGIN EXCLUSIVE)
+
+   This variable is set by with-locked-transaction macro and should not
+   be set directly by user code.")
+
+(defparameter *sqlite3-lock-module-loaded* nil
+  "Flag indicating whether sqlite3-lock module has been loaded.
+
+   Set to T after src/model/impl/sqlite3-lock.lisp is successfully loaded.
+   Used to ensure the module is loaded only once.")
 
 (defparameter +ENVIRONMENT-NAMES+ '("DEVELOP" "TEST" "PRODUCTION")
   "List of valid environment names.")
 
 (defun check-environment-name (env-name)
   "Check if the given environment name is valid.
-   
+
    @param env-name [string] Environment name to validate
    @return [boolean] T if valid, NIL otherwise
    "
@@ -82,10 +142,10 @@
 
 (defun set-environment (env-name)
   "Set the project environment if the name is valid.
-   
+
    Valid environment names are DEVELOP, TEST, and PRODUCTION (case-insensitive).
    Updates *project-environment* with the keyword version of the name.
-   
+
    @param env-name [string] Environment name to set
    @return [keyword] The set environment keyword, or NIL if invalid
    "

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -19,6 +19,8 @@
                 #:destroy)
   (:import-from #:clails/model/transaction
                 #:with-transaction)
+  (:import-from #:clails/model/lock
+                #:with-locked-transaction)
   (:import-from #:clails/model/impl/sqlite3)
   (:import-from #:clails/model/impl/mysql)
   (:import-from #:clails/model/impl/postgresql)
@@ -38,8 +40,8 @@
            #:save
            #:make-record
            #:destroy
-
-           #:with-transaction))
+           #:with-transaction
+           #:with-locked-transaction))
 
 
 

--- a/src/model/impl/sqlite3-lock.lisp
+++ b/src/model/impl/sqlite3-lock.lisp
@@ -1,0 +1,40 @@
+(in-package #:cl-user)
+(defpackage #:clails/model/impl/sqlite3-lock
+  (:use #:cl)
+  (:import-from #:clails/environment
+                #:*sqlite3-transaction-mode*)
+  (:import-from #:clails/logger
+                #:log-level-enabled-p
+                #:log.sql)
+  (:import-from #:dbd.sqlite3
+                #:dbd-sqlite3-connection))
+(in-package #:clails/model/impl/sqlite3-lock)
+
+
+;;;; ========================================
+;;;; Override begin-transaction for SQLite3
+
+(defmethod dbi:begin-transaction ((conn dbd.sqlite3:dbd-sqlite3-connection))
+  "Override begin-transaction for SQLite3 to support lock modes.
+   
+   Checks *sqlite3-transaction-mode* to determine which BEGIN statement to use.
+   This allows with-locked-transaction to control the transaction lock level
+   while maintaining compatibility with regular with-transaction usage.
+
+   Transaction modes:
+   - :immediate -> BEGIN IMMEDIATE
+   - :exclusive -> BEGIN EXCLUSIVE
+   - nil        -> BEGIN TRANSACTION (default)
+
+   @param conn [dbd-sqlite3-connection] SQLite3 database connection
+   "
+  (let* ((tx-mode clails/environment:*sqlite3-transaction-mode*)
+         (begin-sql (case tx-mode
+                      (:immediate "BEGIN IMMEDIATE")
+                      (:exclusive "BEGIN EXCLUSIVE")
+                      (otherwise "BEGIN TRANSACTION"))))
+    (when (log-level-enabled-p :sql :debug)
+      (log.sql begin-sql))
+    (sqlite:execute-non-query 
+     (dbi.driver:connection-handle conn) 
+     begin-sql)))

--- a/src/model/lock.lisp
+++ b/src/model/lock.lisp
@@ -1,0 +1,339 @@
+(in-package #:cl-user)
+(defpackage #:clails/model/lock
+  (:use #:cl)
+  (:import-from #:clails/environment
+                #:*default-lock-mode*
+                #:*database-type*
+                #:*sqlite3-busy-timeout*
+                #:*sqlite3-lock-retry-count*
+                #:*sqlite3-transaction-mode*
+                #:*sqlite3-lock-module-loaded*)
+  (:import-from #:clails/model/query
+                #:execute-query)
+  (:import-from #:clails/model/connection
+                #:get-connection)
+  (:import-from #:clails/logger
+                #:log-level-enabled-p
+                #:log.sql)
+  (:export #:with-locked-transaction
+           #:load-sqlite3-lock-module))
+(in-package #:clails/model/lock)
+
+
+;;;; ========================================
+;;;; Export Macro
+
+(defmacro with-locked-transaction ((variable-name query-spec parameter-plist
+                                    &key (mode '*default-lock-mode*) nowait skip-locked)
+                                   &body body)
+  "Execute body within a transaction with locked records.
+
+   Creates a transaction, retrieves and locks records based on the query specification,
+   then executes the body. The transaction is automatically committed on success
+   or rolled back on error.
+
+   For SQLite3, sets *sqlite3-transaction-mode* to control BEGIN statement type,
+   and implements retry logic on lock errors with exponential backoff.
+
+   @param variable-name [symbol] Variable to bind the retrieved record(s)
+   @param query-spec [query form] Query form like (query <model> ...)
+   @param parameter-plist [plist] Parameters for the query
+   @param mode [keyword] Lock mode (default: *default-lock-mode*)
+                         - PostgreSQL: :for-update, :for-share, :for-no-key-update, :for-key-share
+                         - MySQL: :for-update, :for-share
+                         - SQLite3: :immediate, :exclusive
+   @param nowait [boolean] If T, don't wait for lock
+   @param skip-locked [boolean] If T, skip locked rows
+   @return [value] Returns the value of the last form in body
+
+   SQLite3 :exclusive mode note:
+   While :exclusive mode can be specified for SQLite3, use it with extreme caution.
+   When :exclusive is used, ALL other connections will fail with errors, even those
+   not using locks. This can cause unintended errors in other parts of the application.
+   For most use cases, :immediate mode is recommended.
+
+   Example:
+   (with-locked-transaction (book
+                             (query <book> :as :b :where (:= (:b :id) :book-id))
+                             '(:book-id 1))
+     (setf (ref book :title) \"New Title\")
+     (save book))
+   "
+  (let ((connection-var (gensym "CONNECTION"))
+        (query-var (gensym "QUERY"))
+        (mode-var (gensym "MODE")))
+    `(let* ((,connection-var (get-connection))
+            (,mode-var ,mode))
+
+       ;; check lock mode
+       (check-lock-mode *database-type* ,mode-var)
+
+       ;; Set busy timeout for SQLite3
+       (set-busy-timeout *database-type* ,connection-var)
+
+       (when (log-level-enabled-p :sql :debug)
+         (log.sql (format nil "BEGIN LOCKED TRANSACTION (mode: ~A)" ,mode-var)))
+
+       ;; Retry logic for SQLite3 lock errors
+       (retry-on-lock-error *database-type*
+         (lambda ()
+           ;; Set transaction mode for SQLite3
+           (let ((clails/environment:*sqlite3-transaction-mode* ,mode-var))
+             (dbi-cp:with-transaction ,connection-var
+               ;; Evaluate query and add lock clause
+               (let* ((,query-var ,query-spec)
+                      (,query-var (build-lock-query ,query-var ,mode-var
+                                                    :nowait ,nowait
+                                                    :skip-locked ,skip-locked))
+                      (,variable-name (execute-query ,query-var ,parameter-plist
+                                                     :connection ,connection-var)))
+                 ,@body))))))))
+
+
+;;;; ========================================
+;;;; Export Function
+
+(defun load-sqlite3-lock-module ()
+  "Load sqlite3-lock module for SQLite3 database.
+
+   Loads src/model/impl/sqlite3-lock.lisp if the module hasn't been loaded yet.
+   This function should be called from startup-connection-pool when database type is SQLite3.
+
+   @return [boolean] T if module was loaded, NIL if already loaded
+   "
+  (unless clails/environment:*sqlite3-lock-module-loaded*
+    (when (log-level-enabled-p :sql :info)
+      (log.sql "Loading SQLite3 lock module"))
+    (load (merge-pathnames "src/model/impl/sqlite3-lock.lisp"
+                           (asdf:system-source-directory :clails)))
+    (setf clails/environment:*sqlite3-lock-module-loaded* t)
+    t))
+
+
+;;;; ========================================
+;;;; Internal Functions
+
+(defun build-lock-query (query-spec mode &key nowait skip-locked)
+  "Build a query with lock clause.
+
+   Adds lock clause to the existing query specification based on
+   the database type and lock mode.
+
+   @param query-spec [<query>] Original query specification
+   @param mode [keyword] Lock mode
+   @param nowait [boolean] NOWAIT option
+   @param skip-locked [boolean] SKIP LOCKED option
+   @return [<query>] Query with lock clause
+   "
+  (let ((lock-clause (generate-lock-clause *database-type* mode
+                                           :nowait nowait
+                                           :skip-locked skip-locked)))
+    ;; Copy query and add lock clause
+    (setf (slot-value query-spec 'clails/model/query::lock-clause) lock-clause)
+    query-spec))
+
+
+(defun retry-on-lock-error (database-type thunk)
+  "Execute thunk with retry logic for lock errors.
+
+   For SQLite3, retries on SQLITE_BUSY errors with exponential backoff.
+   For PostgreSQL/MySQL, executes thunk without retry.
+
+   @param database-type [<database-type>] Database type instance
+   @param thunk [function] Function to execute
+   @return [value] Returns the value of thunk
+   "
+  (if (typep database-type 'clails/environment:<database-type-sqlite3>)
+      (retry-on-sqlite3-lock-error thunk)
+      (funcall thunk)))
+
+
+(defun retry-on-sqlite3-lock-error (thunk)
+  "Retry thunk on SQLite3 lock errors with exponential backoff.
+
+   @param thunk [function] Function to execute
+   @return [value] Returns the value of thunk
+   "
+  (let ((max-retries clails/environment:*sqlite3-lock-retry-count*)
+        (retry-count 0))
+    (loop
+      (handler-case
+          (return (funcall thunk))
+        (error (e)
+          (if (and (< retry-count max-retries)
+                   (search "database is locked" (format nil "~A" e)))
+              (progn
+                (incf retry-count)
+                (let ((wait-ms (* 100 (expt 2 (1- retry-count)))))
+                  (when (log-level-enabled-p :sql :warn)
+                    (log.sql (format nil "SQLite3 database locked, retry ~A/~A after ~Ams"
+                                     retry-count max-retries wait-ms)))
+                  (sleep (/ wait-ms 1000.0))))
+              (error e)))))))
+
+
+
+;;;; ========================================
+;;;; Generic Functions
+
+(defgeneric check-lock-mode (database-type mode)
+  (:documentation "Validate that the specified lock mode is supported by the database type.
+
+   Raises an error if the lock mode is not supported.
+
+   @param database-type [<database-type>] Database type instance
+   @param mode [keyword] Lock mode to validate
+   "))
+
+(defgeneric set-busy-timeout (database-type connection)
+  (:documentation "Set busy timeout for database connection.
+
+   For SQLite3, sets the busy timeout to wait for locked database.
+   For PostgreSQL/MySQL, this is a no-op.
+
+   @param database-type [<database-type>] Database type instance
+   @param connection [dbi:<dbi-connection>] Database connection
+   "))
+
+(defmethod set-busy-timeout ((db clails/environment:<database-type-postgresql>) connection)
+  "PostgreSQL does not need busy timeout setting.
+
+   @param db [<database-type-postgresql>] PostgreSQL database type instance
+   @param connection [dbi:<dbi-connection>] Database connection (ignored)
+   @return [null] Always returns NIL
+   "
+  (declare (ignore connection))
+  nil)
+
+(defmethod set-busy-timeout ((db clails/environment:<database-type-mysql>) connection)
+  "MySQL does not need busy timeout setting.
+
+   @param db [<database-type-mysql>] MySQL database type instance
+   @param connection [dbi:<dbi-connection>] Database connection (ignored)
+   @return [null] Always returns NIL
+   "
+  (declare (ignore connection))
+  nil)
+
+(defmethod set-busy-timeout ((db clails/environment:<database-type-sqlite3>) connection)
+  "Set SQLite3 busy timeout in milliseconds.
+
+   @param db [<database-type-sqlite3>] SQLite3 database type instance
+   @param connection [dbi:<dbi-connection>] Database connection
+   @return [null] Returns NIL
+   "
+  (let ((timeout-ms clails/environment:*sqlite3-busy-timeout*))
+    (when (log-level-enabled-p :sql :debug)
+      (log.sql (format nil "PRAGMA busy_timeout = ~A" timeout-ms)))
+    (dbi-cp:execute
+     (dbi-cp:prepare connection (format nil "PRAGMA busy_timeout = ~A" timeout-ms))
+     '())))
+
+(defmethod set-busy-timeout ((db clails/environment:<database-type-dummy>) connection)
+  "Dummy database does not need busy timeout setting.
+
+   @param db [<database-type-dummy>] Dummy database type instance
+   @param connection [dbi:<dbi-connection>] Database connection (ignored)
+   @return [null] Always returns NIL
+   "
+  (declare (ignore connection))
+  nil)
+
+(defmethod check-lock-mode ((db clails/environment:<database-type-postgresql>) mode)
+  "Validate PostgreSQL lock mode.
+
+   Supported modes: :for-update, :for-share, :for-no-key-update, :for-key-share
+
+   @param db [<database-type-postgresql>] PostgreSQL database type instance
+   @param mode [keyword] Lock mode to validate
+   @condition error Raised when unsupported lock mode is specified
+   "
+  (unless (member mode '(:for-update :for-share :for-no-key-update :for-key-share))
+    (error "Unsupported lock mode ~A for PostgreSQL. Supported modes: :for-update, :for-share, :for-no-key-update, :for-key-share" mode)))
+
+(defmethod check-lock-mode ((db clails/environment:<database-type-mysql>) mode)
+  "Validate MySQL lock mode.
+
+   Supported modes: :for-update, :for-share
+
+   @param db [<database-type-mysql>] MySQL database type instance
+   @param mode [keyword] Lock mode to validate
+   @condition error Raised when unsupported lock mode is specified
+   "
+  (unless (member mode '(:for-update :for-share))
+    (error "Unsupported lock mode ~A for MySQL. Supported modes: :for-update, :for-share" mode)))
+
+(defmethod check-lock-mode ((db clails/environment:<database-type-sqlite3>) mode)
+  "Validate SQLite3 lock mode.
+
+   Supported modes: :immediate, :exclusive, :deferred
+
+   @param db [<database-type-sqlite3>] SQLite3 database type instance
+   @param mode [keyword] Lock mode to validate
+   @condition error Raised when unsupported lock mode is specified
+   "
+  (unless (member mode '(:immediate :exclusive :deferred))
+    (error "Unsupported lock mode ~A for SQLite3. Supported modes: :immediate, :exclusive, :deferred" mode)))
+
+(defmethod check-lock-mode ((db clails/environment:<database-type-dummy>) mode)
+  "Dummy database accepts any lock mode.
+
+   @param db [<database-type-dummy>] Dummy database type instance
+   @param mode [keyword] Lock mode (ignored)
+   @return [null] Always returns NIL
+   "
+  (declare (ignore mode))
+  nil)
+
+
+(defgeneric generate-lock-clause (database-type mode &key nowait skip-locked)
+  (:documentation "Generate database-specific lock clause.
+
+   @param database-type [<database-type>] Database type instance
+   @param mode [keyword] Lock mode
+   @param nowait [boolean] NOWAIT option
+   @param skip-locked [boolean] SKIP LOCKED option
+   @return [string] SQL lock clause
+   "))
+
+(defmethod generate-lock-clause ((db clails/environment:<database-type-postgresql>) mode
+                                 &key nowait skip-locked)
+  "Generate PostgreSQL lock clause."
+  (let ((lock-type (case mode
+                     (:for-update "FOR UPDATE")
+                     (:for-share "FOR SHARE")
+                     (:for-no-key-update "FOR NO KEY UPDATE")
+                     (:for-key-share "FOR KEY SHARE")
+                     (otherwise nil)))
+        (options (append (when nowait (list "NOWAIT"))
+                        (when skip-locked (list "SKIP LOCKED")))))
+    (if options
+        (format nil "~A ~{~A~^ ~}" lock-type options)
+        lock-type)))
+
+(defmethod generate-lock-clause ((db clails/environment:<database-type-mysql>) mode
+                                &key nowait skip-locked)
+  "Generate MySQL lock clause."
+  (let ((lock-type (case mode
+                     (:for-update "FOR UPDATE")
+                     (:for-share "FOR SHARE")
+                     (otherwise nil)))
+        (options (append (when nowait (list "NOWAIT"))
+                        (when skip-locked (list "SKIP LOCKED")))))
+    (if options
+        (format nil "~A ~{~A~^ ~}" lock-type options)
+        lock-type)))
+
+(defmethod generate-lock-clause ((db clails/environment:<database-type-sqlite3>) mode
+                                &key nowait skip-locked)
+  "Generate SQLite3 lock clause.
+
+   SQLite3 does not support row-level locks.
+   Returns nil as locking is handled at transaction level."
+  nil)  ; Locking is handled at transaction level, not in SQL
+
+(defmethod generate-lock-clause ((db clails/environment:<database-type-dummy>) mode
+                                &key nowait skip-locked)
+  "Generate dummy lock clause (returns nil)."
+  (declare (ignore mode nowait skip-locked))
+  nil)

--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -73,6 +73,9 @@
    (offset :initarg :offset
            :initform nil
            :documentation "OFFSET value")
+    (lock-clause :initarg :lock-clause
+                 :initform nil
+                 :documentation "Lock clause for pessimistic locking")
    (inst :type 'clails/model/base-model::<base-model>
          :documentation "Model instance")
    (alias->model :initform (make-hash-table)
@@ -420,7 +423,8 @@
            (order-by (generate-order-by (slot-value query 'order-by)))
            (offset (generate-offset (slot-value query 'offset)))
            (limit (generate-limit (slot-value query 'limit)))
-           (sql-template (format nil "SELECT ~{~A~^, ~} FROM ~A as ~A~@[ ~A~]~@[ WHERE ~A~]~@[ ORDER BY ~{~A~^, ~}~]~@[ LIMIT ~A~]~@[ OFFSET ~A~]"
+           (lock-clause (slot-value query 'lock-clause))
+           (sql-template (format nil "SELECT ~{~A~^, ~} FROM ~A as ~A~@[ ~A~]~@[ WHERE ~A~]~@[ ORDER BY ~{~A~^, ~}~]~@[ LIMIT ~A~]~@[ OFFSET ~A~]~@[ ~A~]"
                                  columns
                                  base-table-name
                                  (kebab->snake base-alias)
@@ -428,7 +432,8 @@
                                  (first where-parts)
                                  order-by
                                  (getf limit :limit)
-                                 (getf offset :offset)))
+                                 (getf offset :offset)
+                                 lock-clause))
            (named-params (append (second where-parts)
                                           (ensure-list (getf limit :keyword))
                                           (ensure-list (getf offset :keyword)))))

--- a/test/data/0008-pessimistic-lock-test/db/migrate/20251206-000000-create-lockbooks-table.lisp
+++ b/test/data/0008-pessimistic-lock-test/db/migrate/20251206-000000-create-lockbooks-table.lisp
@@ -1,0 +1,12 @@
+(in-package #:clails-test/model/db/pessimistic-lock)
+
+(defmigration "20251206-000000-create-lockbooks-table"
+    (:up #'(lambda (conn)
+             (create-table conn :table "pessimistic-lock-books"
+                                :columns '(("title" :type :string
+                                                    :not-null T)
+                                           ("price" :type :integer
+                                                    :not-null T))))
+     :down #'(lambda (conn)
+               (drop-table conn :table "pessimistic-lock-books"))))
+

--- a/test/model/pessimistic-lock/lock-mysql.lisp
+++ b/test/model/pessimistic-lock/lock-mysql.lisp
@@ -1,0 +1,256 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/pessimistic-lock/lock-mysql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/base-model
+                #:<base-model>
+                #:defmodel
+                #:ref
+                #:initialize-table-information)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool)
+  (:import-from #:bordeaux-threads
+                #:make-thread
+                #:join-thread))
+
+(defpackage #:clails-test/model/db/pessimistic-lock
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/pessimistic-lock/lock-mysql)
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  (defmodel <book> (<base-model>)
+    (:table "pessimistic_lock_books"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0008" "/app/test/data/0008-pessimistic-lock-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+ (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+ (shutdown-connection-pool))
+
+(defun cleanup-books ()
+  "Delete all records from pessimistic_lock_books table.
+
+   @return [null] Always returns NIL
+   "
+  (let ((connection (clails/model/connection:get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM pessimistic_lock_books") '())))
+
+
+(deftest test-with-lock-for-update
+  (testing "with-lock FOR UPDATE locks record"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Test Book" :price 1000)))
+      (save book)
+
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update)
+        (ok (not (null locked-book)))
+        (ok (string= "Test Book" (ref (first locked-book) :title)))))))
+
+
+(deftest test-with-lock-for-share
+  (testing "with-lock FOR SHARE locks record"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Shared Book" :price 2000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-share)
+        (ok (not (null locked-book)))
+        (ok (string= "Shared Book" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-nowait
+  (testing "with-lock with NOWAIT option"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "NOWAIT Test" :price 3000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update
+                                :nowait t)
+        (ok (not (null locked-book)))
+        (ok (string= "NOWAIT Test" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-skip-locked
+  (testing "with-lock with SKIP LOCKED option"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "SKIP LOCKED Test" :price 4000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update
+                                :skip-locked t)
+        (ok (not (null locked-book)))
+        (ok (string= "SKIP LOCKED Test" (ref (first locked-book) :title)))))))
+
+
+(deftest test-unsupported-lock-mode
+  (testing "Unsupported lock modes raise error"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Error Test" :price 5000)))
+      (save book)
+
+      (ok (signals
+           (with-locked-transaction (locked-book
+                                     (query <book> :as :b :where (:= (:b :id) :book-id))
+                                     `(:book-id ,(ref book :id))
+                                     :mode :for-no-key-update)
+             locked-book)
+           'error)
+          "FOR NO KEY UPDATE should raise error in MySQL"))))
+
+(deftest test-lock-contention-waits
+  (testing "Lock contention: main thread waits and sees updated value"
+    (cleanup-books)
+
+    (let* ((book (make-record '<book> :title "Contention Test" :price 1000))
+           (lock-acquired nil)
+           (update-completed nil))
+      (save book)
+      (let* ((book-id (ref book :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3)
+                                 (setf (ref (first locked-book) :price) 2000)
+                                 (save (first locked-book))
+                                 (setf update-completed t))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "lock-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock")
+        (ok (not update-completed) "Background thread should not complete yet")
+
+        (let ((start-time (get-universal-time)))
+          (with-locked-transaction (locked-book
+                                    (query <book> :as :b :where (:= (:b :id) :book-id))
+                                    `(:book-id ,book-id)
+                                    :mode :for-update)
+            (let ((elapsed (- (get-universal-time) start-time)))
+              (ok (>= elapsed 2) "Main thread should wait at least 2 seconds")
+              (ok update-completed "Background thread should complete before main thread acquires lock")
+              (ok (= 2000 (ref (first locked-book) :price))
+                  "Main thread should see updated value from background thread in SELECT FOR UPDATE"))))
+
+        (bt:join-thread bg-thread)))))
+
+(deftest test-lock-contention-nowait                                                                                  [1/1912]
+  (testing "Lock contention: NOWAIT raises error immediately"
+    (cleanup-books)
+
+    (let* ((book (make-record '<book> :title "NOWAIT Contention Test" :price 1000))
+           (lock-acquired nil))
+      (save book)
+      (let* ((book-id (ref book :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "nowait-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock")
+
+        (ok (signals (with-locked-transaction (locked-book
+                                               (query <book> :as :b :where (:= (:b :id) :book-id))
+                                               `(:book-id ,book-id)
+                                               :mode :for-update
+                                               :nowait t)
+                       (ok nil "Should not reach here"))
+                     'error)
+            "NOWAIT should raise error when lock is held")
+
+        (bt:join-thread bg-thread)))))
+
+(deftest test-lock-contention-skip-locked
+  (testing "Lock contention: SKIP LOCKED returns unlocked rows only"
+    (cleanup-books)
+
+    (let* ((book1 (make-record '<book> :title "Skip Test 1" :price 1000))
+           (book2 (make-record '<book> :title "Skip Test 2" :price 2000))
+           (lock-acquired nil))
+      (save book1)
+      (save book2)
+      (let* ((book1-id (ref book1 :id))
+             (book2-id (ref book2 :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book1-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "skip-locked-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock on book1")
+
+        (with-locked-transaction (locked-books
+                                  (query <book> :as :b :where (:in (:b :id) :book-ids))
+                                  `(:book-ids (,book1-id ,book2-id))
+                                  :mode :for-update
+                                  :skip-locked t)
+          (ok (= 1 (length locked-books))
+              "SKIP LOCKED should return only unlocked book")
+          (ok (= book2-id (ref (first locked-books) :id))
+              "SKIP LOCKED should return book2 (unlocked)"))
+
+        (bt:join-thread bg-thread)))))

--- a/test/model/pessimistic-lock/lock-postgresql.lisp
+++ b/test/model/pessimistic-lock/lock-postgresql.lisp
@@ -1,0 +1,266 @@
+(in-package #:cl-user)                                                                                              [198/1841]
+(defpackage #:clails-test/model/pessimistic-lock/lock-postgresql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/base-model
+                #:<base-model>
+                #:defmodel
+                #:ref
+                #:initialize-table-information)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool)
+  (:import-from #:bordeaux-threads
+                #:make-thread
+                #:join-thread))
+
+(defpackage #:clails-test/model/db/pessimistic-lock
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/pessimistic-lock/lock-postgresql)
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  (defmodel <book> (<base-model>)
+    (:table "pessimistic_lock_books"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-postgresql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "CLAILS_POSTGRESQL_DATABASE" "clails_test")
+                :username ,(env-or-default "CLAILS_POSTGRESQL_USERNAME" "clails")
+                :password ,(env-or-default "CLAILS_POSTGRESQL_PASSWORD" "password")
+                :host ,(env-or-default "CLAILS_POSTGRESQL_HOST" "postgresql-test")
+                :port ,(env-or-default "CLAILS_POSTGRESQL_PORT" "5432"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0008" "/app/test/data/0008-pessimistic-lock-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (shutdown-connection-pool))
+
+(defun cleanup-books ()
+  "Delete all records from pessimistic_lock_books table.
+
+   @return [null] Always returns NIL
+   "
+  (let ((connection (clails/model/connection:get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM pessimistic_lock_books") '())))
+
+(deftest test-with-lock-for-update
+  (testing "with-lock FOR UPDATE locks record"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Test Book" :price 1000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update)
+        (ok (not (null locked-book)))
+        (ok (string= "Test Book" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-for-share
+  (testing "with-lock FOR SHARE locks record"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Shared Book" :price 2000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-share)
+        (ok (not (null locked-book)))
+        (ok (string= "Shared Book" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-for-no-key-update
+  (testing "with-lock FOR NO KEY UPDATE (PostgreSQL specific)"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "No Key Update" :price 3000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-no-key-update)
+        (ok (not (null locked-book)))
+        (ok (string= "No Key Update" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-for-key-share
+  (testing "with-lock FOR KEY SHARE (PostgreSQL specific)"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Key Share" :price 4000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-key-share)
+        (ok (not (null locked-book)))
+        (ok (string= "Key Share" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-nowait                                                                                       [77/1841]
+  (testing "with-lock with NOWAIT option"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "NOWAIT Test" :price 5000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update
+                                :nowait t)
+        (ok (not (null locked-book)))
+        (ok (string= "NOWAIT Test" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-skip-locked
+  (testing "with-lock with SKIP LOCKED option"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "SKIP LOCKED Test" :price 6000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :for-update
+                                :skip-locked t)
+        (ok (not (null locked-book)))
+        (ok (string= "SKIP LOCKED Test" (ref (first locked-book) :title)))))))
+
+(deftest test-lock-contention-waits
+  (testing "Lock contention: main thread waits and sees updated value"
+    (cleanup-books)
+
+    (let* ((book (make-record '<book> :title "Contention Test" :price 1000))
+           (lock-acquired nil)
+           (update-completed nil))
+      (save book)
+      (let* ((book-id (ref book :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3)
+                                 (setf (ref (first locked-book) :price) 2000)
+                                 (save (first locked-book))
+                                 (setf update-completed t))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "lock-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock")
+        (ok (not update-completed) "Background thread should not complete yet")
+
+        (let ((start-time (get-universal-time)))
+          (with-locked-transaction (locked-book
+                                    (query <book> :as :b :where (:= (:b :id) :book-id))
+                                    `(:book-id ,book-id)
+                                    :mode :for-update)
+              (let ((elapsed (- (get-universal-time) start-time)))
+                (ok (>= elapsed 2) "Main thread should wait at least 2 seconds")
+                (ok update-completed "Background thread should complete before main thread acquires lock")
+                (ok (= 2000 (ref (first locked-book) :price))
+                    "Main thread should see updated value from background thread in SELECT FOR UPDATE"))))
+
+        (bt:join-thread bg-thread)))))
+
+(deftest test-lock-contention-nowait
+  (testing "Lock contention: NOWAIT raises error immediately"
+    (cleanup-books)
+
+    (let* ((book (make-record '<book> :title "NOWAIT Contention Test" :price 1000))
+           (lock-acquired nil))
+      (save book)
+      (let* ((book-id (ref book :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "nowait-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock")
+
+        (ok (signals (with-locked-transaction (locked-book
+                                               (query <book> :as :b :where (:= (:b :id) :book-id))
+                                               `(:book-id ,book-id)
+                                               :mode :for-update
+                                               :nowait t)
+                       (ok nil "Should not reach here"))
+                     'error)
+            "NOWAIT should raise error when lock is held")
+
+        (bt:join-thread bg-thread)))))
+
+(deftest test-lock-contention-skip-locked
+  (testing "Lock contention: SKIP LOCKED returns unlocked rows only"
+    (cleanup-books)
+
+    (let* ((book1 (make-record '<book> :title "Skip Test 1" :price 1000))
+           (book2 (make-record '<book> :title "Skip Test 2" :price 2000))
+           (lock-acquired nil))
+      (save book1)
+      (save book2)
+      (let* ((book1-id (ref book1 :id))
+             (book2-id (ref book2 :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (with-locked-transaction (locked-book
+                                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                                         `(:book-id ,book1-id)
+                                                         :mode :for-update)
+                                 (setf lock-acquired t)
+                                 (sleep 3))
+                             (error (e)
+                               (format t "Background thread error: ~A~%" e))))
+                         :name "skip-locked-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock on book1")
+
+        (with-locked-transaction (locked-books
+                                  (query <book> :as :b :where (:in (:b :id) :book-ids))
+                                  `(:book-ids (,book1-id ,book2-id))
+                                  :mode :for-update
+                                  :skip-locked t)
+          (ok (= 1 (length locked-books))
+              "SKIP LOCKED should return only unlocked book")
+          (ok (= book2-id (ref (first locked-books) :id))
+              "SKIP LOCKED should return book2 (unlocked)"))
+
+        (bt:join-thread bg-thread)))))
+
+

--- a/test/model/pessimistic-lock/lock-sqlite3.lisp
+++ b/test/model/pessimistic-lock/lock-sqlite3.lisp
@@ -1,0 +1,165 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/pessimistic-lock/lock-sqlite3
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/base-model
+                #:<base-model>
+                #:defmodel
+                #:ref
+                #:initialize-table-information)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool)
+  (:import-from #:clails/environment
+                #:*sqlite3-busy-timeout*)
+  (:import-from #:bordeaux-threads
+                #:make-thread
+                #:join-thread)
+  (:import-from #:dbi
+                #:connect
+                #:disconnect))
+
+(defpackage #:clails-test/model/db/pessimistic-lock
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/pessimistic-lock/lock-sqlite3)
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  (defmodel <book> (<base-model>)
+    (:table "pessimistic_lock_books"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-sqlite3>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(namestring (merge-pathnames "db/test.db" uiop:*temporary-directory*)))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0008" "/app/test/data/0008-pessimistic-lock-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+(defun cleanup-books ()
+  "Delete all records from pessimistic_lock_books table.
+
+   @return [null] Always returns NIL
+   "
+  (let ((connection (clails/model/connection:get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM pessimistic_lock_books") '())))
+
+
+(deftest test-with-lock-immediate
+  (testing "with-lock :immediate executes BEGIN IMMEDIATE"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Test Book" :price 1000)))
+      (save book)
+
+      (with-locked-transaction (locked-book
+                                (query <book> :as :b :where (:= (:b :id) :book-id))
+                                `(:book-id ,(ref book :id))
+                                :mode :immediate)
+        (ok (not (null locked-book)))
+        (ok (string= "Test Book" (ref (first locked-book) :title)))))))
+
+(deftest test-with-lock-exclusive
+    (testing "with-lock :exclusive executes BEGIN EXCLUSIVE"
+             (cleanup-books)
+
+             (let ((book (make-record '<book> :title "Test Book" :price 1000)))
+               (save book)
+
+               (with-locked-transaction (locked-book
+                                         (query <book> :as :b :where (:= (:b :id) :book-id))
+                                         `(:book-id ,(ref book :id))
+                                         :mode :exclusive)
+                 (ok (not (null locked-book)))
+                 (ok (string= "Test Book" (ref (first locked-book) :title)))))))
+
+(deftest test-unsupported-lock-modes
+  (testing "Row-level lock modes raise error in SQLite3"
+    (cleanup-books)
+
+    (let ((book (make-record '<book> :title "Error Test" :price 2000)))
+      (save book)
+
+      (ok (signals
+           (with-locked-transaction (locked-book
+                                     (query <book> :as :b :where (:= (:b :id) :book-id))
+                                     `(:book-id ,(ref book :id))
+                                     :mode :for-update)
+             locked-book)
+           'error)
+          "FOR UPDATE should raise error in SQLite3")
+
+      (ok (signals
+           (with-locked-transaction (locked-book
+                                     (query <book> :as :b :where (:= (:b :id) :book-id))
+                                     `(:book-id ,(ref book :id))
+                                     :mode :for-share)
+             locked-book)
+           'error)
+          "FOR SHARE should raise error in SQLite3"))))
+
+(deftest test-lock-contention-waits
+  (testing "Lock contention: main thread waits and sees updated value"
+    (cleanup-books)
+
+    (let* ((book (make-record '<book> :title "Contention Test" :price 1000))
+           (lock-acquired nil)
+           (update-completed nil)
+           (db-path (getf (getf clails/environment:*database-config* :test) :database-name))
+           (*sqlite3-busy-timeout* 500))
+      (save book)
+      (let* ((book-id (ref book :id))
+             (bg-thread (bt:make-thread
+                         (lambda ()
+                           (handler-case
+                               (let ((bg-conn (dbi:connect :sqlite3 :database-name db-path)))
+                                 (unwind-protect
+                                      (progn
+                                        (dbi:do-sql bg-conn "BEGIN IMMEDIATE")
+                                        (dbi:do-sql bg-conn "SELECT * FROM pessimistic_lock_books WHERE id = ?" (list book-id))
+                                        (setf lock-acquired t)
+                                        (sleep 3)
+                                        (dbi:do-sql bg-conn "UPDATE pessimistic_lock_books SET price = ?, updated_at = current_timestamp WHERE id = ?"
+                                                   (list 2000  book-id))
+                                        (dbi:do-sql bg-conn "COMMIT")
+                                        (setf update-completed t))
+                                   (dbi:disconnect bg-conn)))
+                             (error (e)
+                               (format *standard-output* "Background thread error: ~A~%" e))))
+                         :name "lock-bg-thread")))
+
+        (sleep 1)
+        (ok lock-acquired "Background thread should acquire lock")
+        (ok (not update-completed) "Background thread should not complete yet")
+
+        (let ((start-time (get-universal-time)))
+          (with-locked-transaction (locked-book
+                                    (query <book> :as :b :where (:= (:b :id) :book-id))
+                                    `(:book-id ,book-id)
+                                    :mode :immediate)
+            (let ((elapsed (- (get-universal-time) start-time)))
+              (ok (>= elapsed 2) "Main thread should wait at least 2 seconds")
+              (ok update-completed "Background thread should complete before main thread acquires lock")
+              (ok (= 2000 (ref (first locked-book) :price))
+                  "Main thread should see updated value from background thread"))))
+
+        (bt:join-thread bg-thread)))))
+


### PR DESCRIPTION
## Overview

Implemented pessimistic locking functionality for databases.
The `with-locked-transaction` macro allows locking records within a transaction for concurrency control.

## Key Changes

### 1. Added `with-locked-transaction` Macro

Implemented a macro to lock query results within a transaction.

**Usage Example:**
```common-lisp
(with-locked-transaction (book
                          (query <book> :as :b :where (:= (:b :id) :book-id))
                          '(:book-id 1)
                          :mode :for-update)
  (setf (ref book :title) "New Title")
  (save book))
```

### 2. Database-Specific Lock Mode Support

Supports lock modes appropriate for each database:

#### PostgreSQL
- `:for-update` - Exclusive lock (default)
- `:for-share` - Shared lock
- `:for-no-key-update` - PostgreSQL-specific
- `:for-key-share` - PostgreSQL-specific

#### MySQL
- `:for-update` - Exclusive lock (default)
- `:for-share` - Shared lock

#### SQLite3
- `:immediate` - Acquires write lock at transaction start
- `:exclusive` - Exclusive transaction (**Caution: Use with care**)
- `:deferred` - Deferred lock (default)

### 3. Special Handling for SQLite3

#### Transaction Mode Override
- Added `src/model/impl/sqlite3-lock.lisp`
- Overrides `dbi:begin-transaction` method to support `BEGIN IMMEDIATE` and `BEGIN EXCLUSIVE`
- Controls transaction mode via dynamic variable `*sqlite3-transaction-mode*`

#### Retry Mechanism
- Automatic retry on SQLite3 database lock errors
- Exponential backoff for retry intervals
- Configurable retry count via `*sqlite3-lock-retry-count*` (default: 3 retries)

#### Busy Timeout Configuration
- Configurable lock wait time via `*sqlite3-busy-timeout*` (default: 50ms)

### 4. New Environment Variables and Configuration

Added the following configuration items to `src/environment.lisp`:

- `*default-lock-mode*` - Default lock mode (default: `:for-update`)
- `*sqlite3-busy-timeout*` - SQLite3 busy timeout (default: 50ms)
- `*sqlite3-lock-retry-count*` - SQLite3 retry count (default: 3 retries)
- `*sqlite3-transaction-mode*` - SQLite3 transaction mode (internal use)
- `*sqlite3-lock-module-loaded*` - Flag indicating sqlite3-lock module load status

### 5. Lock Mode Validation

Implemented `check-lock-mode` generic function to raise an error when an unsupported lock mode is specified for a database type.

### 6. Added Tests

Added comprehensive tests for each database:

- `test/model/pessimistic-lock/lock-postgresql.lisp` - PostgreSQL tests
- `test/model/pessimistic-lock/lock-mysql.lisp` - MySQL tests
- `test/model/pessimistic-lock/lock-sqlite3.lisp` - SQLite3 tests

## Important Notes

### About SQLite3 `:exclusive` Mode

When `:exclusive` mode is specified in SQLite3, **all other connections will encounter errors**. This includes processes that are not lock-aware, so use with extreme caution. For most use cases, `:immediate` mode is sufficient.

## Related Issue

Closes: #41

## Testing Checklist

- [x] Verify pessimistic lock operation with PostgreSQL
- [x] Verify pessimistic lock operation with MySQL
- [x] Verify pessimistic lock operation with SQLite3
- [x] Confirm all database tests pass successfully

## Impact Scope

- Minimal impact on existing functionality as this is a new feature
- `src/model/impl/sqlite3-lock.lisp` is automatically loaded when using SQLite3
- No impact on `with-transaction` behavior (backward compatible)