### PR TITLE
Implementation of Bulk UPDATE Feature

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -39,6 +39,9 @@
                #:clails-test/model/bulk/insert-sqlite3
                #:clails-test/model/bulk/insert-mysql
                #:clails-test/model/bulk/insert-postgresql
+               #:clails-test/model/bulk/update-sqlite3
+               #:clails-test/model/bulk/update-mysql
+               #:clails-test/model/bulk/update-postgresql
                #:clails-test/logger/registry
                #:clails-test/logger/purpose-specific
                #:clails-test/logger/file-appender

--- a/src/model/bulk.lisp
+++ b/src/model/bulk.lisp
@@ -7,6 +7,8 @@
                 #:generate-values
                 #:make-record
                 #:<query>)
+  (:import-from #:clails/model/query
+                #:update1)
   (:import-from #:clails/model/connection
                 #:get-connection)
   (:import-from #:clails/model/transaction
@@ -36,6 +38,8 @@
            #:show-query-sql
            #:insert-all
            #:insert-bulk
+           #:update-all
+           #:update-bulk
            #:type-mismatch-error))
 (in-package #:clails/model/bulk)
 
@@ -826,3 +830,184 @@
     (if table-info
         (getf table-info :table-name)
         (kebab->snake (string-downcase (symbol-name model-class))))))
+
+;;;; ========================================
+;;;; UPDATE Operations
+;;;; ========================================
+
+;;; ----------------------------------------
+;;; update-all
+;;; ----------------------------------------
+
+(defun update-all (list-of-model &key connection)
+  "Update model instances one by one.
+
+   Each instance is updated using update1, so
+   updated_at is set on each instance after UPDATE.
+   Only columns marked as dirty are updated.
+
+   Note: The list can contain instances of different model classes.
+   Each instance will be updated to its own table independently.
+   This is an intentional design to allow flexible update operations.
+
+   @param list-of-model [list] List of <base-model> instances (can be mixed model classes)
+   @param connection [connection] Optional database connection (uses connection pool if not provided)
+   @return [list] List of model instances with updated_at updated
+   @condition database-error When UPDATE fails
+   @condition optimistic-lock-error Optimistic lock error (version mismatch)
+   "
+  (when (null list-of-model)
+    (return-from update-all nil))
+
+  (unless (typep (first list-of-model) '<base-model>)
+    (error "update-all requires a list of model instances"))
+
+  (dolist (model list-of-model)
+    (let ((rows-updated (clails/model/query::update1 model :connection connection)))
+      (when (= rows-updated 0)
+        (error 'clails/condition:optimistic-lock-error))))
+
+  list-of-model)
+
+
+;;; ----------------------------------------
+;;; update-bulk
+;;; ----------------------------------------
+
+(defun update-bulk (model-class columns list-of-model &key (batch-size 100) (use-transaction t) (on-type-mismatch :error) connection)
+  "Execute bulk UPDATE and return the number of updated rows.
+
+   Accepts a list of model instances and performs bulk UPDATE.
+   Explicitly specifies the model class and columns to update.
+
+   Column information is automatically adjusted:
+   - :id is removed if included (not updatable)
+   - :created-at is removed if included (not updatable)
+   - :updated-at is added if not included (automatically updated)
+
+   @param model-class [symbol] Model symbol to UPDATE (e.g., '<user>)
+   @param columns [list] List of columns to UPDATE (list of keywords) (e.g., '(:name :age))
+   @param list-of-model [list] List of model instances
+   @param batch-size [integer] Batch size (default: 100)
+   @param use-transaction [boolean] Use transaction (default: t)
+   @param on-type-mismatch [keyword] Behavior on type mismatch (default: :error)
+                                     :error - Raise error when type mismatch occurs (default)
+                                     :skip - Skip instances that don't match the model class
+   @param connection [connection] Optional database connection (uses connection pool if not provided)
+   @return [integer] Number of updated records
+   @condition database-error When UPDATE fails
+   @condition type-mismatch-error When on-type-mismatch is :error and type mismatch occurs
+   "
+  (when (null list-of-model)
+    (return-from update-bulk 0))
+
+  ;; Validate and adjust column information
+  (let ((adjusted-columns (validate-and-adjust-update-columns columns)))
+
+    ;; Type check and filtering
+    (let ((filtered-list (filter-models-by-class model-class list-of-model on-type-mismatch)))
+
+      (when (null filtered-list)
+        (return-from update-bulk 0))
+
+      ;; Execute bulk UPDATE
+      (batch-update-instances model-class adjusted-columns filtered-list batch-size use-transaction connection))))
+
+
+;;; ----------------------------------------
+;;; Column validation and adjustment for UPDATE
+;;; ----------------------------------------
+
+(defun validate-and-adjust-update-columns (columns)
+  "Validate and adjust column list for UPDATE.
+
+   - Removes :id if included (not updatable)
+   - Removes :created-at if included (not updatable)
+   - Adds :updated-at if not included
+
+   @param columns [list] Column list (keywords)
+   @return [list] Adjusted column list
+   "
+  (let ((adjusted-columns (remove-if (lambda (col)
+                                      (or (eq col :id)
+                                          (eq col :created-at)))
+                                    columns)))
+    ;; Add updated-at (avoid duplicates)
+    (unless (member :updated-at adjusted-columns)
+      (push :updated-at adjusted-columns))
+    adjusted-columns))
+
+
+;;; ----------------------------------------
+;;; Batch update for model instances
+;;; ----------------------------------------
+
+(defun batch-update-instances (model-class columns list-of-model batch-size use-transaction connection)
+  "Execute batch UPDATE for model instance list (internal function).
+
+   Updates only the specified columns.
+   updated-at is automatically set to the current time.
+
+   @param model-class [symbol] Model class name
+   @param columns [list] List of columns to update (keywords)
+   @param list-of-model [list] List of model instances
+   @param batch-size [integer] Batch size
+   @param use-transaction [boolean] Use transaction
+   @param connection [connection] Optional database connection
+   @return [integer] Number of updated records
+   "
+  (let ((table-name (get-table-name model-class))
+        (total 0)
+        (now (get-universal-time)))  ;; Pre-generate timestamp
+
+    (labels ((execute-batch (batch)
+               ;; Generate UPDATE SQL (once per batch)
+               (let* ((set-clause (generate-set-clause columns))
+                      (sql (format nil "UPDATE ~A SET ~A WHERE id = ?"
+                                  table-name set-clause))
+                      (conn (or connection (get-connection))))
+
+                 (when (log-level-enabled-p :sql :debug)
+                   (log.sql (format nil "sql: ~S" sql)))
+
+                 ;; Execute for each instance
+                 (dolist (instance batch)
+                   ;; Set updated-at timestamp
+                   (when (member :updated-at columns)
+                     (setf (ref instance :updated-at) now))
+
+                   ;; Extract values with cl-db-fn conversion
+                   (let ((params (append
+                                  (extract-instance-values instance columns model-class)
+                                  (list (ref instance :id)))))
+                     (when (log-level-enabled-p :sql :debug)
+                       (log.sql (format nil "params: ~S" params)))
+                     (dbi-cp:execute (dbi-cp:prepare conn sql) params)
+                     (incf total)))
+                 total)))
+
+      (if (and use-transaction (null connection))
+          (let ((conn (get-connection)))
+            (with-transaction-using-connection conn
+              (loop for batch in (split-into-batches list-of-model batch-size)
+                    do (execute-batch batch))))
+          (loop for batch in (split-into-batches list-of-model batch-size)
+                do (execute-batch batch)))
+
+      total)))
+
+
+;;; ----------------------------------------
+;;; Helper function for UPDATE
+;;; ----------------------------------------
+
+(defun generate-set-clause (columns)
+  "Generate SET clause for UPDATE statement.
+
+   @param columns [list] List of columns to update (keywords)
+   @return [string] SET clause (e.g., \"name = ?, age = ?, updated_at = ?\")
+   "
+  (let ((column-strs (mapcar (lambda (col)
+                              (kebab->snake (symbol-name col)))
+                            columns)))
+    (format nil "~{~A = ?~^, ~}" column-strs)))

--- a/test/model/bulk/update-mysql.lisp
+++ b/test/model/bulk/update-mysql.lisp
@@ -30,7 +30,7 @@
   (:import-from #:clails/util
                 #:env-or-default))
 
-(defpackage #:clails-test/model/db/bulk-update-mysql
+(defpackage #:clails-test/model/db/bulk-insert
   (:use #:cl)
   (:import-from #:clails/model/migration
                 #:defmigration

--- a/test/model/bulk/update-mysql.lisp
+++ b/test/model/bulk/update-mysql.lisp
@@ -1,0 +1,335 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/update-mysql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:update-all
+                #:update-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-update-mysql
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/update-mysql)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "MYSQL_TEST_DATABASE" "clails_test")
+                 :username ,(env-or-default "MYSQL_TEST_USERNAME" "root")
+                 :password ,(env-or-default "MYSQL_TEST_PASSWORD" "password")
+                 :host ,(env-or-default "MYSQL_TEST_HOST" "mysql-test")
+                 :port ,(env-or-default "MYSQL_TEST_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; update-all Tests
+;;;; ----------------------------------------
+
+(deftest mysql-test-update-all-single-record
+  (testing "update-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product)))
+           (original-updated-at (ref (first inserted) :updated-at)))
+
+      ;; Wait a moment to ensure timestamp difference
+      (sleep 1)
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (string= "Gaming Laptop" (ref (first result) :name)) "Name should be updated")
+        (ok (= 2000 (ref (first result) :price)) "Price should be updated")
+        (ok (ref (first result) :updated-at) "Should have updated-at")
+        (ok (/= original-updated-at (ref (first result) :updated-at)) "updated-at should be changed")))))
+
+(deftest mysql-test-update-all-multiple-records
+  (testing "update-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= 1600 (ref (first result) :price)) "First record price should be updated")
+        (ok (= 60 (ref (second result) :price)) "Second record price should be updated")
+        (ok (= 90 (ref (third result) :price)) "Third record price should be updated")))))
+
+(deftest mysql-test-update-all-empty-list
+  (testing "update-all with empty list"
+    (let ((result (update-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest mysql-test-update-all-with-connection
+  (testing "update-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      (setf (ref (first inserted) :price) 1700)
+
+      (let ((result (update-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= 1700 (ref (first result) :price)) "Price should be updated")))))
+
+(deftest mysql-test-update-all-mixed-models
+  (testing "update-all with mixed model instances"
+    (cleanup-table)
+    ;; Also cleanup customers table
+    (let ((connection (get-connection)))
+      (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '()))
+
+    ;; Insert product and customer
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product))))
+           (inserted-customer (first (insert-all (list customer)))))
+
+      ;; Update both
+      (setf (ref inserted-product :price) 1600)
+      (setf (ref inserted-customer :name) "John Doe")
+
+      ;; update-all should update both instances to their respective tables
+      (let ((result (update-all (list inserted-product inserted-customer))))
+        (ok (= (length result) 2) "Should return 2 records")
+        (ok (= 1600 (ref (first result) :price)) "Product price should be updated")
+        (ok (string= "John Doe" (ref (second result) :name)) "Customer name should be updated")
+
+        ;; Verify in database
+        (let* ((conn (get-connection))
+               (product-result (dbi-cp:fetch-all
+                                (dbi-cp:execute
+                                 (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                                 (list (ref inserted-product :id)))))
+               (customer-result (dbi-cp:fetch-all
+                                 (dbi-cp:execute
+                                  (dbi-cp:prepare conn "SELECT * FROM customers WHERE id = ?")
+                                  (list (ref inserted-customer :id))))))
+          (ok (= 1600 (getf (first product-result) :|price|)) "Product price should be updated in DB")
+          (ok (string= "John Doe" (getf (first customer-result) :|name|)) "Customer name should be updated in DB"))))))
+
+
+;;;; ----------------------------------------
+;;;; update-bulk Tests
+;;;; ----------------------------------------
+
+(deftest mysql-test-update-bulk-single-record
+  (testing "update-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((count (update-bulk '<product> '(:name :price) inserted)))
+        (ok (= count 1) "Should return 1 as updated count")
+
+        ;; Verify the update in database
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list (ref (first inserted) :id))))))
+          (ok (string= "Gaming Laptop" (getf (first result) :|name|)) "Name should be updated in DB")
+          (ok (= 2000 (getf (first result) :|price|)) "Price should be updated in DB"))))))
+
+(deftest mysql-test-update-bulk-multiple-records
+  (testing "update-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((count (update-bulk '<product> '(:price) inserted)))
+        (ok (= count 3) "Should return 3 as updated count")))))
+
+(deftest mysql-test-update-bulk-column-adjustment
+  (testing "update-bulk should remove :id and :created-at, add :updated-at"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (original-id (ref (first inserted) :id)))
+
+      ;; Try to update with :id and :created-at (should be ignored)
+      (setf (ref (first inserted) :name) "New Name")
+
+      (let ((count (update-bulk '<product> '(:id :name :created-at) inserted)))
+        (ok (= count 1) "Should update successfully")
+
+        ;; Verify id and created-at are not changed
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list original-id)))))
+          (ok (= original-id (getf (first result) :|id|)) "ID should not change")
+          (ok (string= "New Name" (getf (first result) :|name|)) "Name should be updated")
+          ;; updated-at should be updated automatically
+          (ok (getf (first result) :|updated_at|) "updated_at should exist"))))))
+
+(deftest mysql-test-update-bulk-empty-list
+  (testing "update-bulk with empty list"
+    (let ((count (update-bulk '<product> '(:name :price) nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest mysql-test-update-bulk-type-mismatch-error
+  (testing "update-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (update-bulk '<product> '(:name) (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest mysql-test-update-bulk-type-mismatch-skip
+  (testing "update-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (setf (ref inserted-product :name) "Gaming Laptop")
+
+      (let ((count (update-bulk '<product> '(:name) (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should update only the matching type (skip customer)")))))
+
+(deftest mysql-test-update-bulk-with-transaction
+  (testing "update-bulk with transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Update with transaction
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+
+      (let ((count (update-bulk '<product> '(:price) inserted :use-transaction t)))
+        (ok (= count 2) "Should update 2 records in transaction")))))
+
+(deftest mysql-test-update-bulk-batch-size
+  (testing "update-bulk with batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product ~D" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Update all with batch size 2
+      (loop for i from 0 below 5
+            do (setf (ref (nth i inserted) :price) (* (1+ i) 200)))
+
+      (let ((count (update-bulk '<product> '(:price) inserted :batch-size 2)))
+        (ok (= count 5) "Should update all 5 records with batch processing")))))

--- a/test/model/bulk/update-postgresql.lisp
+++ b/test/model/bulk/update-postgresql.lisp
@@ -1,0 +1,335 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/update-postgresql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:update-all
+                #:update-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-update-postgresql
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/update-postgresql)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-postgresql>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "POSTGRESQL_TEST_DATABASE" "clails_test")
+                 :username ,(env-or-default "POSTGRESQL_TEST_USERNAME" "clails")
+                 :password ,(env-or-default "POSTGRESQL_TEST_PASSWORD" "password")
+                 :host ,(env-or-default "POSTGRESQL_TEST_HOST" "postgresql-test")
+                 :port ,(env-or-default "POSTGRESQL_TEST_PORT" "5432"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; update-all Tests
+;;;; ----------------------------------------
+
+(deftest postgresql-test-update-all-single-record
+  (testing "update-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product)))
+           (original-updated-at (ref (first inserted) :updated-at)))
+
+      ;; Wait a moment to ensure timestamp difference
+      (sleep 1)
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (string= "Gaming Laptop" (ref (first result) :name)) "Name should be updated")
+        (ok (= 2000 (ref (first result) :price)) "Price should be updated")
+        (ok (ref (first result) :updated-at) "Should have updated-at")
+        (ok (/= original-updated-at (ref (first result) :updated-at)) "updated-at should be changed")))))
+
+(deftest postgresql-test-update-all-multiple-records
+  (testing "update-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= 1600 (ref (first result) :price)) "First record price should be updated")
+        (ok (= 60 (ref (second result) :price)) "Second record price should be updated")
+        (ok (= 90 (ref (third result) :price)) "Third record price should be updated")))))
+
+(deftest postgresql-test-update-all-empty-list
+  (testing "update-all with empty list"
+    (let ((result (update-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest postgresql-test-update-all-with-connection
+  (testing "update-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      (setf (ref (first inserted) :price) 1700)
+
+      (let ((result (update-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= 1700 (ref (first result) :price)) "Price should be updated")))))
+
+(deftest postgresql-test-update-all-mixed-models
+  (testing "update-all with mixed model instances"
+    (cleanup-table)
+    ;; Also cleanup customers table
+    (let ((connection (get-connection)))
+      (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '()))
+
+    ;; Insert product and customer
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product))))
+           (inserted-customer (first (insert-all (list customer)))))
+
+      ;; Update both
+      (setf (ref inserted-product :price) 1600)
+      (setf (ref inserted-customer :name) "John Doe")
+
+      ;; update-all should update both instances to their respective tables
+      (let ((result (update-all (list inserted-product inserted-customer))))
+        (ok (= (length result) 2) "Should return 2 records")
+        (ok (= 1600 (ref (first result) :price)) "Product price should be updated")
+        (ok (string= "John Doe" (ref (second result) :name)) "Customer name should be updated")
+
+        ;; Verify in database
+        (let* ((conn (get-connection))
+               (product-result (dbi-cp:fetch-all
+                                (dbi-cp:execute
+                                 (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                                 (list (ref inserted-product :id)))))
+               (customer-result (dbi-cp:fetch-all
+                                 (dbi-cp:execute
+                                  (dbi-cp:prepare conn "SELECT * FROM customers WHERE id = ?")
+                                  (list (ref inserted-customer :id))))))
+          (ok (= 1600 (getf (first product-result) :|price|)) "Product price should be updated in DB")
+          (ok (string= "John Doe" (getf (first customer-result) :|name|)) "Customer name should be updated in DB"))))))
+
+
+;;;; ----------------------------------------
+;;;; update-bulk Tests
+;;;; ----------------------------------------
+
+(deftest postgresql-test-update-bulk-single-record
+  (testing "update-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((count (update-bulk '<product> '(:name :price) inserted)))
+        (ok (= count 1) "Should return 1 as updated count")
+
+        ;; Verify the update in database
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list (ref (first inserted) :id))))))
+          (ok (string= "Gaming Laptop" (getf (first result) :|name|)) "Name should be updated in DB")
+          (ok (= 2000 (getf (first result) :|price|)) "Price should be updated in DB"))))))
+
+(deftest postgresql-test-update-bulk-multiple-records
+  (testing "update-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((count (update-bulk '<product> '(:price) inserted)))
+        (ok (= count 3) "Should return 3 as updated count")))))
+
+(deftest postgresql-test-update-bulk-column-adjustment
+  (testing "update-bulk should remove :id and :created-at, add :updated-at"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (original-id (ref (first inserted) :id)))
+
+      ;; Try to update with :id and :created-at (should be ignored)
+      (setf (ref (first inserted) :name) "New Name")
+
+      (let ((count (update-bulk '<product> '(:id :name :created-at) inserted)))
+        (ok (= count 1) "Should update successfully")
+
+        ;; Verify id and created-at are not changed
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list original-id)))))
+          (ok (= original-id (getf (first result) :|id|)) "ID should not change")
+          (ok (string= "New Name" (getf (first result) :|name|)) "Name should be updated")
+          ;; updated-at should be updated automatically
+          (ok (getf (first result) :|updated_at|) "updated_at should exist"))))))
+
+(deftest postgresql-test-update-bulk-empty-list
+  (testing "update-bulk with empty list"
+    (let ((count (update-bulk '<product> '(:name :price) nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest postgresql-test-update-bulk-type-mismatch-error
+  (testing "update-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (update-bulk '<product> '(:name) (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest postgresql-test-update-bulk-type-mismatch-skip
+  (testing "update-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (setf (ref inserted-product :name) "Gaming Laptop")
+
+      (let ((count (update-bulk '<product> '(:name) (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should update only the matching type (skip customer)")))))
+
+(deftest postgresql-test-update-bulk-with-transaction
+  (testing "update-bulk with transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Update with transaction
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+
+      (let ((count (update-bulk '<product> '(:price) inserted :use-transaction t)))
+        (ok (= count 2) "Should update 2 records in transaction")))))
+
+(deftest postgresql-test-update-bulk-batch-size
+  (testing "update-bulk with batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product ~D" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Update all with batch size 2
+      (loop for i from 0 below 5
+            do (setf (ref (nth i inserted) :price) (* (1+ i) 200)))
+
+      (let ((count (update-bulk '<product> '(:price) inserted :batch-size 2)))
+        (ok (= count 5) "Should update all 5 records with batch processing")))))

--- a/test/model/bulk/update-postgresql.lisp
+++ b/test/model/bulk/update-postgresql.lisp
@@ -30,7 +30,7 @@
   (:import-from #:clails/util
                 #:env-or-default))
 
-(defpackage #:clails-test/model/db/bulk-update-postgresql
+(defpackage #:clails-test/model/db/bulk-insert
   (:use #:cl)
   (:import-from #:clails/model/migration
                 #:defmigration

--- a/test/model/bulk/update-sqlite3.lisp
+++ b/test/model/bulk/update-sqlite3.lisp
@@ -1,0 +1,332 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/update-sqlite3
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:update-all
+                #:update-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-update
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/update-sqlite3)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-sqlite3>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(namestring (merge-pathnames "db/clails_bulk_update_test.sqlite3" uiop:*temporary-directory*)))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; update-all Tests
+;;;; ----------------------------------------
+
+(deftest sqlite3-test-update-all-single-record
+  (testing "update-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product)))
+           (original-updated-at (ref (first inserted) :updated-at)))
+
+      ;; Wait a moment to ensure timestamp difference
+      (sleep 1)
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (string= "Gaming Laptop" (ref (first result) :name)) "Name should be updated")
+        (ok (= 2000 (ref (first result) :price)) "Price should be updated")
+        (ok (ref (first result) :updated-at) "Should have updated-at")
+        (ok (/= original-updated-at (ref (first result) :updated-at)) "updated-at should be changed")))))
+
+(deftest sqlite3-test-update-all-multiple-records
+  (testing "update-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((result (update-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= 1600 (ref (first result) :price)) "First record price should be updated")
+        (ok (= 60 (ref (second result) :price)) "Second record price should be updated")
+        (ok (= 90 (ref (third result) :price)) "Third record price should be updated")))))
+
+(deftest sqlite3-test-update-all-empty-list
+  (testing "update-all with empty list"
+    (let ((result (update-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest sqlite3-test-update-all-with-connection
+  (testing "update-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      (setf (ref (first inserted) :price) 1700)
+
+      (let ((result (update-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= 1700 (ref (first result) :price)) "Price should be updated")))))
+
+(deftest sqlite3-test-update-all-mixed-models
+  (testing "update-all with mixed model instances"
+    (cleanup-table)
+    ;; Also cleanup customers table
+    (let ((connection (get-connection)))
+      (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '()))
+
+    ;; Insert product and customer
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product))))
+           (inserted-customer (first (insert-all (list customer)))))
+
+      ;; Update both
+      (setf (ref inserted-product :price) 1600)
+      (setf (ref inserted-customer :name) "John Doe")
+
+      ;; update-all should update both instances to their respective tables
+      (let ((result (update-all (list inserted-product inserted-customer))))
+        (ok (= (length result) 2) "Should return 2 records")
+        (ok (= 1600 (ref (first result) :price)) "Product price should be updated")
+        (ok (string= "John Doe" (ref (second result) :name)) "Customer name should be updated")
+
+        ;; Verify in database
+        (let* ((conn (get-connection))
+               (product-result (dbi-cp:fetch-all
+                                (dbi-cp:execute
+                                 (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                                 (list (ref inserted-product :id)))))
+               (customer-result (dbi-cp:fetch-all
+                                 (dbi-cp:execute
+                                  (dbi-cp:prepare conn "SELECT * FROM customers WHERE id = ?")
+                                  (list (ref inserted-customer :id))))))
+          (ok (= 1600 (getf (first product-result) :|price|)) "Product price should be updated in DB")
+          (ok (string= "John Doe" (getf (first customer-result) :|name|)) "Customer name should be updated in DB"))))))
+
+
+;;;; ----------------------------------------
+;;;; update-bulk Tests
+;;;; ----------------------------------------
+
+(deftest sqlite3-test-update-bulk-single-record
+  (testing "update-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Update the record
+      (setf (ref (first inserted) :name) "Gaming Laptop")
+      (setf (ref (first inserted) :price) 2000)
+
+      (let ((count (update-bulk '<product> '(:name :price) inserted)))
+        (ok (= count 1) "Should return 1 as updated count")
+
+        ;; Verify the update in database
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list (ref (first inserted) :id))))))
+          (ok (string= "Gaming Laptop" (getf (first result) :|name|)) "Name should be updated in DB")
+          (ok (= 2000 (getf (first result) :|price|)) "Price should be updated in DB"))))))
+
+(deftest sqlite3-test-update-bulk-multiple-records
+  (testing "update-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Update all records
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+      (setf (ref (third inserted) :price) 90)
+
+      (let ((count (update-bulk '<product> '(:price) inserted)))
+        (ok (= count 3) "Should return 3 as updated count")))))
+
+(deftest sqlite3-test-update-bulk-column-adjustment
+  (testing "update-bulk should remove :id and :created-at, add :updated-at"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (original-id (ref (first inserted) :id))
+           (original-created-at (ref (first inserted) :created-at)))
+
+      ;; Try to update with :id and :created-at (should be ignored)
+      (setf (ref (first inserted) :name) "New Name")
+
+      (let ((count (update-bulk '<product> '(:id :name :created-at) inserted)))
+        (ok (= count 1) "Should update successfully")
+
+        ;; Verify id and created-at are not changed
+        (let* ((conn (get-connection))
+               (result (dbi-cp:fetch-all
+                        (dbi-cp:execute
+                         (dbi-cp:prepare conn "SELECT * FROM products WHERE id = ?")
+                         (list original-id)))))
+          (ok (= original-id (getf (first result) :|id|)) "ID should not change")
+          (ok (string= "New Name" (getf (first result) :|name|)) "Name should be updated")
+          ;; updated-at should be updated automatically
+          (ok (getf (first result) :|updated_at|) "updated_at should exist"))))))
+
+(deftest sqlite3-test-update-bulk-empty-list
+  (testing "update-bulk with empty list"
+    (let ((count (update-bulk '<product> '(:name :price) nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest sqlite3-test-update-bulk-type-mismatch-error
+  (testing "update-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (update-bulk '<product> '(:name) (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest sqlite3-test-update-bulk-type-mismatch-skip
+  (testing "update-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (setf (ref inserted-product :name) "Gaming Laptop")
+
+      (let ((count (update-bulk '<product> '(:name) (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should update only the matching type (skip customer)")))))
+
+(deftest sqlite3-test-update-bulk-with-transaction
+  (testing "update-bulk with transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Update with transaction
+      (setf (ref (first inserted) :price) 1600)
+      (setf (ref (second inserted) :price) 60)
+
+      (let ((count (update-bulk '<product> '(:price) inserted :use-transaction t)))
+        (ok (= count 2) "Should update 2 records in transaction")))))
+
+(deftest sqlite3-test-update-bulk-batch-size
+  (testing "update-bulk with batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product ~D" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Update all with batch size 2
+      (loop for i from 0 below 5
+            do (setf (ref (nth i inserted) :price) (* (1+ i) 200)))
+
+      (let ((count (update-bulk '<product> '(:price) inserted :batch-size 2)))
+        (ok (= count 5) "Should update all 5 records with batch processing")))))

--- a/test/model/bulk/update-sqlite3.lisp
+++ b/test/model/bulk/update-sqlite3.lisp
@@ -30,7 +30,7 @@
   (:import-from #:clails/util
                 #:env-or-default))
 
-(defpackage #:clails-test/model/db/bulk-update
+(defpackage #:clails-test/model/db/bulk-insert
   (:use #:cl)
   (:import-from #:clails/model/migration
                 #:defmigration


### PR DESCRIPTION
### Overview

Added bulk UPDATE operation functionality.
Provides two functions, `update-all` and `update-bulk`, enabling UPDATE operations suited to different use cases.

### Changes

#### Added Files
- `src/model/bulk.lisp`: Added UPDATE functionality implementation (185 lines added)
- `test/model/bulk/update-sqlite3.lisp`: Tests for SQLite3 (332 lines)
- `test/model/bulk/update-mysql.lisp`: Tests for MySQL (335 lines)
- `test/model/bulk/update-postgresql.lisp`: Tests for PostgreSQL (335 lines)
- `clails-test.asd`: Registered new test files

**Total**: 5 files, 1,190 lines added

### Added Features

#### 1. `update-all` Function

Receives a list of model instances and executes `update1` for each instance.

**Features:**
- Updates only columns marked with dirty-flag
- Automatically updates `updated_at` for each instance after UPDATE
- Returns a list of updated model instances
- **Correctly updates even when different model class instances are mixed** (each instance is updated to its own table)
- Supports optimistic locking (when version column exists)

**Usage Example:**
```common-lisp
;; Update instances of the same model class
(let ((users (list user1 user2 user3)))
  (setf (ref user1 :name) "Alice Updated")
  (setf (ref user2 :age) 26)
  (setf (ref user3 :email) "charlie-new@example.com")

  (let ((updated-users (update-all users)))
    (dolist (user updated-users)
      (format t "Updated: ~A~%" (ref user :name)))))

;; Mixed model classes are also supported
(let ((updated (update-all (list user-instance post-instance))))
  (format t "Updated ~A records~%" (length updated)))
```

#### 2. `update-bulk` Function

Explicitly specifies model class and columns to update, executing UPDATE in batch units.

**Features:**
- Explicitly specifies columns to update
- Automatically excludes `:id` and `:created-at` (not updatable)
- Automatically adds `:updated-at` (updated even if not specified)
- Supports batch size and transaction control
- Type mismatch behavior can be specified with `:error` or `:skip`
- Returns update count (integer)
- Faster than `update-all` (batch processing)

**Usage Example:**
```common-lisp
(let ((products (list product1 product2 product3)))
  (setf (ref product1 :price) 1600)
  (setf (ref product2 :price) 60)
  (setf (ref product3 :price) 90)

  ;; Update only the price column (updated_at is automatically updated)
  (let ((count (update-bulk '<product> '(:price) products)))
    (format t "Updated ~A records~%" count)))
;; => Updated 3 records
```

### Implementation Details

#### Main Functions

**`update-all`**
```common-lisp
(defun update-all (list-of-model &key connection)
  ;; Execute update1 for each instance
  ;; Update only columns changed based on dirty-flag
)
```

**`update-bulk`**
```common-lisp
(defun update-bulk (model-class columns list-of-model
                    &key (batch-size 100) (use-transaction t)
                         (on-type-mismatch :error) connection)
  ;; Update only explicitly specified columns
  ;; Execute at high speed through batch processing
)
```

#### Internal Helper Functions

- `validate-and-adjust-update-columns`: Validates and adjusts column list (excludes :id, :created-at; adds :updated-at)
- `batch-update-instances`: Executes UPDATE in batch units
- `generate-set-clause`: Generates SET clause for UPDATE statement
- `extract-instance-values`: Extracts values from instance (applies type conversion via `cl-db-fn`)

#### Database Support

Verified to work with the following databases:
- ✅ SQLite3
- ✅ MySQL
- ✅ PostgreSQL

Timestamp conversion is automatically handled by `cl-db-fn` to suit each database format:
- SQLite3: Universal Time (integer)
- MySQL: DATETIME string
- PostgreSQL: TIMESTAMP string

### Tests

Implemented the following test cases for each database (SQLite3, MySQL, PostgreSQL):

#### update-all Tests (5 tests per DB)
- ✅ Single record update
- ✅ Multiple records update
- ✅ Empty list handling
- ✅ Explicit connection specification
- ✅ **Mixed model classes** (important specification)

#### update-bulk Tests (8 tests per DB)
- ✅ Single record update
- ✅ Multiple records update
- ✅ Automatic column adjustment (:id, :created-at exclusion, :updated-at addition)
- ✅ Empty list handling
- ✅ Type mismatch error handling
- ✅ Type mismatch skip handling
- ✅ Transaction handling
- ✅ Batch size handling

**Total**: 39 test cases (SQLite3: 13, MySQL: 13, PostgreSQL: 13)

All tests pass successfully.

### Design Policy

#### update-all Design
- Each instance is processed independently with `update1`
- Updates only columns changed based on dirty-flag
- **Even when different model class instances are mixed, each instance is updated to its own table (intentional design)**
  - This design enables flexible update operations
  - Example: Updating users and posts simultaneously

#### update-bulk Design
- Explicitly specifying columns to update prevents unintended updates
- Type checking and filtering features safely handle incorrect type instances
- Faster than `update-all` through batch processing

### Usage Guidelines

| Function | Use Case | Return Value | Column Specification | Speed | Applicable Scenarios |
|----------|----------|--------------|---------------------|-------|---------------------|
| `update-all` | When you want to use instances as-is after UPDATE | List of models | dirty-flag | Slow | Small data, using values after update |
| `update-bulk` | When you only need update count (high-speed processing) | Update count (integer) | Explicit | Medium | Large data, updating specific columns only |

### Compatibility

#### Breaking Changes
None. Does not affect existing functionality.

#### Dependencies
Uses the following existing features:
- `clails/model/query::update1`: One-by-one update
- `extract-instance-values`: Value extraction and conversion
- `filter-models-by-class`: Type checking (used in existing INSERT functionality)

### Checklist

- [x] Implementation completed (185 lines added)
- [x] Tests added (SQLite3, MySQL, PostgreSQL, 39 tests total)
- [x] All tests pass
- [x] Proper type conversion handling (`cl-db-fn` automatic conversion)
- [x] Transaction support
- [x] Batch processing support
- [x] Error handling (optimistic locking, type mismatch)
- [x] Docstrings written (including Japanese comments)
