### PR TITLE
Implementation of Bulk DELETE Feature 

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -42,6 +42,9 @@
                #:clails-test/model/bulk/update-sqlite3
                #:clails-test/model/bulk/update-mysql
                #:clails-test/model/bulk/update-postgresql
+               #:clails-test/model/bulk/delete-sqlite3
+               #:clails-test/model/bulk/delete-mysql
+               #:clails-test/model/bulk/delete-postgresql
                #:clails-test/logger/registry
                #:clails-test/logger/purpose-specific
                #:clails-test/logger/file-appender

--- a/src/model/bulk.lisp
+++ b/src/model/bulk.lisp
@@ -8,7 +8,8 @@
                 #:make-record
                 #:<query>)
   (:import-from #:clails/model/query
-                #:update1)
+                #:update1
+                #:destroy)
   (:import-from #:clails/model/connection
                 #:get-connection)
   (:import-from #:clails/model/transaction
@@ -40,6 +41,8 @@
            #:insert-bulk
            #:update-all
            #:update-bulk
+           #:delete-all
+           #:delete-bulk
            #:type-mismatch-error))
 (in-package #:clails/model/bulk)
 
@@ -1011,3 +1014,116 @@
                               (kebab->snake (symbol-name col)))
                             columns)))
     (format nil "~{~A = ?~^, ~}" column-strs)))
+
+;;;; ========================================
+;;;; DELETE Operations
+;;;; ========================================
+
+;;; ----------------------------------------
+;;; delete-all
+;;; ----------------------------------------
+
+(defun delete-all (list-of-model &key (cascade nil) connection)
+  "Delete model instances one by one.
+
+   Each instance is deleted using destroy.
+   Cascade deletion option can be specified.
+
+   @param list-of-model [list] List of <base-model> instances
+   @param cascade [boolean] Whether to perform cascade delete (default: nil)
+   @param connection [connection] Optional database connection (uses connection pool if not provided)
+   @return [list] List of deleted model instances
+   @condition database-error When DELETE fails
+   "
+  (when (null list-of-model)
+    (return-from delete-all nil))
+
+  (unless (typep (first list-of-model) '<base-model>)
+    (error "delete-all requires a list of model instances"))
+
+  (dolist (model list-of-model)
+    (destroy model :cascade cascade))
+
+  list-of-model)
+
+
+;;; ----------------------------------------
+;;; delete-bulk
+;;; ----------------------------------------
+
+(defun delete-bulk (model-class list-of-model &key (batch-size 100) (use-transaction t) (on-type-mismatch :error) connection)
+  "Execute bulk DELETE and return the number of deleted rows.
+
+   Deletes only instances of the specified model class.
+   Does not support cascade deletion.
+
+   @param model-class [symbol] Model symbol to DELETE (e.g., '<user>)
+   @param list-of-model [list] List of model instances
+   @param batch-size [integer] Batch size (default: 100)
+   @param use-transaction [boolean] Use transaction (default: t)
+   @param on-type-mismatch [keyword] Behavior on type mismatch (default: :error)
+                                     :error - Raise error when type mismatch occurs (default)
+                                     :skip - Skip instances that don't match the model class
+   @param connection [connection] Optional database connection (uses connection pool if not provided)
+   @return [integer] Number of deleted records
+   @condition database-error When DELETE fails
+   @condition type-mismatch-error When on-type-mismatch is :error and type mismatch occurs
+   "
+  (when (null list-of-model)
+    (return-from delete-bulk 0))
+
+  ;; Type check and filtering
+  (let ((filtered-list (filter-models-by-class model-class list-of-model on-type-mismatch)))
+
+    (when (null filtered-list)
+      (return-from delete-bulk 0))
+
+    ;; Execute bulk DELETE
+    (batch-delete-instances model-class filtered-list batch-size use-transaction connection)))
+
+
+;;; ----------------------------------------
+;;; Batch delete for model instances
+;;; ----------------------------------------
+
+(defun batch-delete-instances (model-class list-of-model batch-size use-transaction connection)
+  "Execute batch DELETE for model instance list (internal function).
+
+   Uses IN clause for optimized deletion.
+
+   @param model-class [symbol] Model class name
+   @param list-of-model [list] List of model instances
+   @param batch-size [integer] Batch size
+   @param use-transaction [boolean] Use transaction
+   @param connection [connection] Optional database connection
+   @return [integer] Number of deleted records
+   "
+  (let ((table-name (get-table-name model-class))
+        (total 0))
+
+    (labels ((execute-batch (batch)
+               ;; Extract IDs from batch
+               (let* ((ids (mapcar (lambda (inst) (ref inst :id)) batch))
+                      (placeholders (format nil "~{~A~^, ~}" (make-list (length ids) :initial-element "?")))
+                      (sql (format nil "DELETE FROM ~A WHERE id IN (~A)"
+                                  table-name
+                                  placeholders))
+                      (conn (or connection (get-connection))))
+
+                 (when (log-level-enabled-p :sql :debug)
+                   (log.sql (format nil "sql: ~S" sql))
+                   (log.sql (format nil "params: ~S" ids)))
+
+                 (dbi-cp:execute (dbi-cp:prepare conn sql) ids)
+                 (let ((count (dbi-cp:row-count conn)))
+                   (incf total count)))))
+
+      (if (and use-transaction (null connection))
+          (let ((conn (get-connection)))
+            (with-transaction-using-connection conn
+              (loop for batch in (split-into-batches list-of-model batch-size)
+                    do (execute-batch batch))))
+          (loop for batch in (split-into-batches list-of-model batch-size)
+                do (execute-batch batch)))
+
+      total)))

--- a/test/data/0011-bulk-insert-test/db/migrate/20260107-000001-create-orders-table.lisp
+++ b/test/data/0011-bulk-insert-test/db/migrate/20260107-000001-create-orders-table.lisp
@@ -1,0 +1,17 @@
+(in-package #:clails-test/model/db/bulk-insert)
+
+(defmigration "20260107-000001-create-orders-table"
+  (:up #'(lambda (conn)
+           (create-table conn :table "orders"
+                              :columns '(("customer-id" :type :integer
+                                                        :not-null T)
+                                         ("product-id" :type :integer
+                                                       :not-null T)
+                                         ("quantity" :type :integer
+                                                     :not-null T
+                                                     :default-value 1)
+                                         ("total-price" :type :integer
+                                                        :not-null T)
+                                         ("order-date" :type :string))))
+   :down #'(lambda (conn)
+             (drop-table conn :table "orders"))))

--- a/test/model/bulk/delete-mysql.lisp
+++ b/test/model/bulk/delete-mysql.lisp
@@ -1,0 +1,410 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/delete-mysql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:delete-all
+                #:delete-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-insert
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/delete-mysql)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun cleanup-orders ()
+  "Delete all records from orders table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM orders") '())))
+
+(defun cleanup-customers ()
+  "Delete all records from customers table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-orders ()
+  "Count total records in orders table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM orders")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-customers ()
+  "Count total records in customers table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM customers")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"
+     :relations ((:has-many "clails-test/model/bulk/delete-mysql::<order>"
+                   :as :orders
+                   :foreign-key :customer-id))))
+
+  (defmodel <order> (<base-model>)
+    (:table "orders"
+     :relations ((:belongs-to "clails-test/model/bulk/delete-mysql::<customer>"
+                   :column :customer
+                   :key :customer-id))))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "MYSQL_TEST_DATABASE" "clails_test")
+                 :username ,(env-or-default "MYSQL_TEST_USERNAME" "root")
+                 :password ,(env-or-default "MYSQL_TEST_PASSWORD" "password")
+                 :host ,(env-or-default "MYSQL_TEST_HOST" "mysql-test")
+                 :port ,(env-or-default "MYSQL_TEST_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; delete-all Tests
+;;;; ----------------------------------------
+
+(deftest mysql-test-delete-all-single-record
+  (testing "delete-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-all-multiple-records
+  (testing "delete-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-all-empty-list
+  (testing "delete-all with empty list"
+    (let ((result (delete-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest mysql-test-delete-all-with-cascade
+  (testing "delete-all with cascade deletes related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 2
+                                  :total-price 3000
+                                  :order-date "2024-01-01")
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 2
+                                  :quantity 1
+                                  :total-price 50
+                                  :order-date "2024-01-02")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 2) "Should have 2 orders before delete")
+
+        ;; Load related records into customer instance (required for cascade delete)
+        (setf (ref inserted-customer :orders) inserted-orders)
+
+        ;; Delete customer with cascade
+        (let ((result (delete-all (list inserted-customer) :cascade t)))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 0) "Should have 0 orders after cascade delete"))))))
+
+(deftest mysql-test-delete-all-without-cascade
+  (testing "delete-all without cascade leaves related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "Jane" :email "jane@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 1
+                                  :total-price 1500
+                                  :order-date "2024-01-03")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 1) "Should have 1 order before delete")
+
+        ;; Delete customer without cascade (default)
+        (let ((result (delete-all (list inserted-customer))))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 1) "Should still have 1 order (not cascaded)"))))))
+
+
+(deftest mysql-test-delete-all-with-connection
+  (testing "delete-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((result (delete-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-all-with-transaction
+  (testing "delete-all within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (with-transaction-using-connection connection
+        (delete-all inserted :connection connection))
+
+      ;; Verify deletion
+      (ok (= (count-records) 0) "Should have 0 records after transaction"))))
+
+
+;;;; ----------------------------------------
+;;;; delete-bulk Tests
+;;;; ----------------------------------------
+
+(deftest mysql-test-delete-bulk-single-record
+  (testing "delete-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 1) "Should return 1 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-bulk-multiple-records
+  (testing "delete-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 3) "Should return 3 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-bulk-batch-size
+  (testing "delete-bulk with custom batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product~A" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Delete with batch size 2
+      (let ((count (delete-bulk '<product> inserted :batch-size 2)))
+        (ok (= count 5) "Should delete all 5 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-bulk-empty-list
+  (testing "delete-bulk with empty list"
+    (let ((count (delete-bulk '<product> nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest mysql-test-delete-bulk-type-mismatch-error
+  (testing "delete-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (delete-bulk '<product> (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest mysql-test-delete-bulk-type-mismatch-skip
+  (testing "delete-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (let ((count (delete-bulk '<product> (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should delete only the matching type (skip customer)")
+        (ok (= (count-records) 0) "Should have 0 products after delete")))))
+
+(deftest mysql-test-delete-bulk-with-connection
+  (testing "delete-bulk with explicit connection"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((count (delete-bulk '<product> inserted :connection connection)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest mysql-test-delete-bulk-with-transaction
+  (testing "delete-bulk within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (let ((count nil))
+        (with-transaction-using-connection connection
+          (setf count (delete-bulk '<product> inserted
+                                   :connection connection
+                                   :use-transaction nil)))
+
+        (ok (= count 3) "Should delete 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after transaction")))))
+
+(deftest mysql-test-delete-bulk-without-transaction
+  (testing "delete-bulk without transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Delete without transaction
+      (let ((count (delete-bulk '<product> inserted :use-transaction nil)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))

--- a/test/model/bulk/delete-postgresql.lisp
+++ b/test/model/bulk/delete-postgresql.lisp
@@ -1,0 +1,410 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/delete-postgresql
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:delete-all
+                #:delete-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-insert
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/delete-postgresql)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun cleanup-orders ()
+  "Delete all records from orders table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM orders") '())))
+
+(defun cleanup-customers ()
+  "Delete all records from customers table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-orders ()
+  "Count total records in orders table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM orders")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-customers ()
+  "Count total records in customers table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM customers")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"
+     :relations ((:has-many "clails-test/model/bulk/delete-postgresql::<order>"
+                   :as :orders
+                   :foreign-key :customer-id))))
+
+  (defmodel <order> (<base-model>)
+    (:table "orders"
+     :relations ((:belongs-to "clails-test/model/bulk/delete-postgresql::<customer>"
+                   :column :customer
+                   :key :customer-id))))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-postgresql>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(env-or-default "POSTGRESQL_TEST_DATABASE" "clails_test")
+                 :username ,(env-or-default "POSTGRESQL_TEST_USERNAME" "clails")
+                 :password ,(env-or-default "POSTGRESQL_TEST_PASSWORD" "password")
+                 :host ,(env-or-default "POSTGRESQL_TEST_HOST" "postgresql-test")
+                 :port ,(env-or-default "POSTGRESQL_TEST_PORT" "5432"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; delete-all Tests
+;;;; ----------------------------------------
+
+(deftest postgresql-test-delete-all-single-record
+  (testing "delete-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-all-multiple-records
+  (testing "delete-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-all-empty-list
+  (testing "delete-all with empty list"
+    (let ((result (delete-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest postgresql-test-delete-all-with-cascade
+  (testing "delete-all with cascade deletes related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 2
+                                  :total-price 3000
+                                  :order-date "2024-01-01")
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 2
+                                  :quantity 1
+                                  :total-price 50
+                                  :order-date "2024-01-02")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 2) "Should have 2 orders before delete")
+
+        ;; Load related records into customer instance (required for cascade delete)
+        (setf (ref inserted-customer :orders) inserted-orders)
+
+        ;; Delete customer with cascade
+        (let ((result (delete-all (list inserted-customer) :cascade t)))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 0) "Should have 0 orders after cascade delete"))))))
+
+(deftest postgresql-test-delete-all-without-cascade
+  (testing "delete-all without cascade leaves related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "Jane" :email "jane@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 1
+                                  :total-price 1500
+                                  :order-date "2024-01-03")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 1) "Should have 1 order before delete")
+
+        ;; Delete customer without cascade (default)
+        (let ((result (delete-all (list inserted-customer))))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 1) "Should still have 1 order (not cascaded)"))))))
+
+
+(deftest postgresql-test-delete-all-with-connection
+  (testing "delete-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((result (delete-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-all-with-transaction
+  (testing "delete-all within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (with-transaction-using-connection connection
+        (delete-all inserted :connection connection))
+
+      ;; Verify deletion
+      (ok (= (count-records) 0) "Should have 0 records after transaction"))))
+
+
+;;;; ----------------------------------------
+;;;; delete-bulk Tests
+;;;; ----------------------------------------
+
+(deftest postgresql-test-delete-bulk-single-record
+  (testing "delete-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 1) "Should return 1 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-bulk-multiple-records
+  (testing "delete-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 3) "Should return 3 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-bulk-batch-size
+  (testing "delete-bulk with custom batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product~A" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Delete with batch size 2
+      (let ((count (delete-bulk '<product> inserted :batch-size 2)))
+        (ok (= count 5) "Should delete all 5 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-bulk-empty-list
+  (testing "delete-bulk with empty list"
+    (let ((count (delete-bulk '<product> nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest postgresql-test-delete-bulk-type-mismatch-error
+  (testing "delete-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (delete-bulk '<product> (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest postgresql-test-delete-bulk-type-mismatch-skip
+  (testing "delete-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (let ((count (delete-bulk '<product> (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should delete only the matching type (skip customer)")
+        (ok (= (count-records) 0) "Should have 0 products after delete")))))
+
+(deftest postgresql-test-delete-bulk-with-connection
+  (testing "delete-bulk with explicit connection"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((count (delete-bulk '<product> inserted :connection connection)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest postgresql-test-delete-bulk-with-transaction
+  (testing "delete-bulk within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (let ((count nil))
+        (with-transaction-using-connection connection
+          (setf count (delete-bulk '<product> inserted
+                                   :connection connection
+                                   :use-transaction nil)))
+
+        (ok (= count 3) "Should delete 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after transaction")))))
+
+(deftest postgresql-test-delete-bulk-without-transaction
+  (testing "delete-bulk without transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Delete without transaction
+      (let ((count (delete-bulk '<product> inserted :use-transaction nil)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))

--- a/test/model/bulk/delete-sqlite3.lisp
+++ b/test/model/bulk/delete-sqlite3.lisp
@@ -1,0 +1,406 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/bulk/delete-sqlite3
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection
+                #:release-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction
+                #:with-transaction-using-connection)
+  (:import-from #:clails/model/bulk
+                #:insert-all
+                #:delete-all
+                #:delete-bulk)
+  (:import-from #:clails/model/query
+                #:make-record)
+  (:import-from #:clails/model/migration
+                #:create-table
+                #:drop-table
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db/bulk-insert
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/bulk/delete-sqlite3)
+
+(defun cleanup-table ()
+  "Delete all records from products table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM products") '())))
+
+(defun cleanup-orders ()
+  "Delete all records from orders table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM orders") '())))
+
+(defun cleanup-customers ()
+  "Delete all records from customers table."
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM customers") '())))
+
+(defun count-records ()
+  "Count total records in products table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM products")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-orders ()
+  "Count total records in orders table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM orders")
+                   '()))))
+    (getf (first result) :|count|)))
+
+(defun count-customers ()
+  "Count total records in customers table."
+  (let* ((connection (get-connection))
+         (result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                   (dbi-cp:prepare connection "SELECT COUNT(*) as count FROM customers")
+                   '()))))
+    (getf (first result) :|count|)))
+
+
+(setup
+  (clrhash clails/model/base-model::*table-information*)
+
+  ;; Test model definitions
+  (defmodel <product> (<base-model>)
+    (:table "products"))
+
+  (defmodel <customer> (<base-model>)
+    (:table "customers"
+     :relations ((:has-many "clails-test/model/bulk/delete-sqlite3::<order>"
+                   :as :orders
+                   :foreign-key :customer-id))))
+
+  (defmodel <order> (<base-model>)
+    (:table "orders"
+     :relations ((:belongs-to "clails-test/model/bulk/delete-sqlite3::<customer>"
+                   :column :customer
+                   :key :customer-id))))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-sqlite3>))
+  (setf clails/environment:*project-environment* :test)
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment:*database-config*
+        `(:test (:database-name ,(merge-pathnames "db/test.db" uiop:*temporary-directory*))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0011" "/app/test/data/0011-bulk-insert-test"))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information))
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; delete-all Tests
+;;;; ----------------------------------------
+
+(deftest sqlite3-test-delete-all-single-record
+  (testing "delete-all with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-all-multiple-records
+  (testing "delete-all with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((result (delete-all inserted)))
+        (ok (= (length result) 3) "Should return 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-all-empty-list
+  (testing "delete-all with empty list"
+    (let ((result (delete-all nil)))
+      (ok (null result) "Should return nil for empty list"))))
+
+(deftest sqlite3-test-delete-all-with-cascade
+  (testing "delete-all with cascade deletes related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 2
+                                  :total-price 3000
+                                  :order-date "2024-01-01")
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 2
+                                  :quantity 1
+                                  :total-price 50
+                                  :order-date "2024-01-02")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 2) "Should have 2 orders before delete")
+
+        ;; Load related records into customer instance (required for cascade delete)
+        (setf (ref inserted-customer :orders) inserted-orders)
+
+        ;; Delete customer with cascade
+        (let ((result (delete-all (list inserted-customer) :cascade t)))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 0) "Should have 0 orders after cascade delete"))))))
+
+(deftest sqlite3-test-delete-all-without-cascade
+  (testing "delete-all without cascade leaves related records"
+    (cleanup-customers)
+    (cleanup-orders)
+
+    ;; Insert customer with orders
+    (let* ((customer (make-record '<customer> :name "Jane" :email "jane@example.com"))
+           (inserted-customer (first (insert-all (list customer))))
+           (customer-id (ref inserted-customer :id)))
+
+      ;; Insert orders for this customer
+      (let* ((orders (list
+                      (make-record '<order>
+                                  :customer-id customer-id
+                                  :product-id 1
+                                  :quantity 1
+                                  :total-price 1500
+                                  :order-date "2024-01-03")))
+             (inserted-orders (insert-all orders)))
+
+        ;; Verify data is inserted
+        (ok (= (count-customers) 1) "Should have 1 customer before delete")
+        (ok (= (count-orders) 1) "Should have 1 order before delete")
+
+        ;; Delete customer without cascade (default)
+        (let ((result (delete-all (list inserted-customer))))
+          (ok (= (length result) 1) "Should return 1 deleted customer")
+          (ok (= (count-customers) 0) "Should have 0 customers after delete")
+          (ok (= (count-orders) 1) "Should still have 1 order (not cascaded)"))))))
+
+
+(deftest sqlite3-test-delete-all-with-connection
+  (testing "delete-all with explicit connection"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (inserted (insert-all (list product)))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((result (delete-all inserted :connection connection)))
+        (ok (= (length result) 1) "Should return 1 record")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-all-with-transaction
+  (testing "delete-all within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (with-transaction-using-connection connection
+        (delete-all inserted :connection connection))
+
+      ;; Verify deletion
+      (ok (= (count-records) 0) "Should have 0 records after transaction"))))
+
+
+;;;; ----------------------------------------
+;;;; delete-bulk Tests
+;;;; ----------------------------------------
+
+(deftest sqlite3-test-delete-bulk-single-record
+  (testing "delete-bulk with single record"
+    (cleanup-table)
+
+    ;; Insert a record
+    (let* ((product (make-record '<product>
+                                :name "Laptop"
+                                :price 1500
+                                :stock 10))
+           (inserted (insert-all (list product))))
+
+      ;; Verify insert
+      (ok (= (count-records) 1) "Should have 1 record before delete")
+
+      ;; Delete the record
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 1) "Should return 1 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-bulk-multiple-records
+  (testing "delete-bulk with multiple records"
+    (cleanup-table)
+
+    ;; Insert multiple records
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products)))
+
+      ;; Verify insert
+      (ok (= (count-records) 3) "Should have 3 records before delete")
+
+      ;; Delete all records
+      (let ((count (delete-bulk '<product> inserted)))
+        (ok (= count 3) "Should return 3 as deleted count")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-bulk-batch-size
+  (testing "delete-bulk with custom batch size"
+    (cleanup-table)
+
+    ;; Insert 5 records
+    (let* ((products (loop for i from 1 to 5
+                          collect (make-record '<product>
+                                              :name (format nil "Product~A" i)
+                                              :price (* i 100)
+                                              :stock 10)))
+           (inserted (insert-all products)))
+
+      ;; Delete with batch size 2
+      (let ((count (delete-bulk '<product> inserted :batch-size 2)))
+        (ok (= count 5) "Should delete all 5 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-bulk-empty-list
+  (testing "delete-bulk with empty list"
+    (let ((count (delete-bulk '<product> nil)))
+      (ok (= count 0) "Should return 0 for empty list"))))
+
+(deftest sqlite3-test-delete-bulk-type-mismatch-error
+  (testing "delete-bulk with type mismatch should raise error"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (ok (signals (delete-bulk '<product> (list inserted-product customer)))
+          "Should signal type-mismatch-error"))))
+
+(deftest sqlite3-test-delete-bulk-type-mismatch-skip
+  (testing "delete-bulk with type mismatch :skip option"
+    (cleanup-table)
+
+    (let* ((product (make-record '<product> :name "Laptop" :price 1500 :stock 10))
+           (customer (make-record '<customer> :name "John" :email "john@example.com"))
+           (inserted-product (first (insert-all (list product)))))
+
+      (let ((count (delete-bulk '<product> (list inserted-product customer)
+                                :on-type-mismatch :skip)))
+        (ok (= count 1) "Should delete only the matching type (skip customer)")
+        (ok (= (count-records) 0) "Should have 0 products after delete")))))
+
+(deftest sqlite3-test-delete-bulk-with-connection
+  (testing "delete-bulk with explicit connection"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete with explicit connection
+      (let ((count (delete-bulk '<product> inserted :connection connection)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))
+
+(deftest sqlite3-test-delete-bulk-with-transaction
+  (testing "delete-bulk within transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)
+                      (make-record '<product> :name "Keyboard" :price 80 :stock 50)))
+           (inserted (insert-all products))
+           (connection (get-connection)))
+
+      ;; Delete within transaction
+      (let ((count nil))
+        (with-transaction-using-connection connection
+          (setf count (delete-bulk '<product> inserted
+                                   :connection connection
+                                   :use-transaction nil)))
+
+        (ok (= count 3) "Should delete 3 records")
+        (ok (= (count-records) 0) "Should have 0 records after transaction")))))
+
+(deftest sqlite3-test-delete-bulk-without-transaction
+  (testing "delete-bulk without transaction"
+    (cleanup-table)
+
+    (let* ((products (list
+                      (make-record '<product> :name "Laptop" :price 1500 :stock 10)
+                      (make-record '<product> :name "Mouse" :price 50 :stock 100)))
+           (inserted (insert-all products)))
+
+      ;; Delete without transaction
+      (let ((count (delete-bulk '<product> inserted :use-transaction nil)))
+        (ok (= count 2) "Should delete 2 records")
+        (ok (= (count-records) 0) "Should have 0 records after delete")))))


### PR DESCRIPTION
### Overview

Added bulk DELETE operation functionality.
Provides two functions, `delete-all` and `delete-bulk`, enabling DELETE operations suited to different use cases.

### Changes

#### Added Files
- `src/model/bulk.lisp`: Added DELETE functionality implementation (118 lines added)
- `test/model/bulk/delete-sqlite3.lisp`: SQLite3 tests (406 lines)
- `test/model/bulk/delete-mysql.lisp`: MySQL tests (410 lines)
- `test/model/bulk/delete-postgresql.lisp`: PostgreSQL tests (410 lines)
- `test/data/0011-bulk-insert-test/db/migrate/20260107-000001-create-orders-table.lisp`: Migration for cascade delete tests
- `clails-test.asd`: Registered new test files

**Total**: 5 files changed, 1,346 lines added

### Added Features

#### 1. `delete-all` Function

Accepts a list of model instances and executes `destroy` on each instance.

**Features:**
- Deletes records one by one
- Supports cascade deletion (when related objects are pre-loaded)
- Returns list of deleted model instances
- Transaction support

**Usage Examples:**
```common-lisp
;; Basic deletion
(let ((users (list user1 user2 user3)))
  (let ((deleted-users (delete-all users)))
    (format t "Deleted ~A users~%" (length deleted-users))))

;; Cascade delete (pre-load related records)
(let ((customer (first (find-by '<customer> :id 1))))
  ;; Load related records
  (setf (ref customer :orders) (find-by '<order> :customer-id (ref customer :id)))

  ;; Execute cascade delete
  (delete-all (list customer) :cascade t))
;; => Deletes customer and related orders

;; Execute within transaction
(with-transaction (conn)
  (delete-all users :connection conn))
```

**Parameters:**
- `list-of-model`: List of `<base-model>` instances to delete
- `:cascade` (optional): Whether to perform cascade delete (default: `nil`)
- `:connection` (optional): Explicit database connection

**Returns:**
- List of deleted model instances

#### 2. `delete-bulk` Function

Executes bulk DELETE and returns only the count of deleted records. Implemented with IN clause optimization.

**Features:**
- High-speed bulk deletion using IN clause (`DELETE FROM table WHERE id IN (?, ?, ...)`)
- No cascade delete support (for performance)
- Type checking and filtering support
- Configurable batch size
- Transaction support

**Usage Examples:**
```common-lisp
;; Basic usage
(let ((users (list user1 user2 user3)))
  (let ((count (delete-bulk '<user> users)))
    (format t "Deleted ~A records~%" count)))
;; => Deleted 3 records

;; Custom batch size
(delete-bulk '<user> large-user-list :batch-size 50)

;; Type mismatch behavior
;; Default is :error - raises error if different types exist
(delete-bulk '<user> (list user1 product1 user2))
;; => Signals type-mismatch-error

;; :skip - Skip instances of different types
(delete-bulk '<user> (list user1 product1 user2) :on-type-mismatch :skip)
;; => 2 (deletes only user1 and user2, skips product1)

;; Execute within transaction
(with-transaction (conn)
  (delete-bulk '<user> users
               :connection conn
               :use-transaction nil))  ;; External transaction management
```

**Parameters:**
- `model-class`: Model symbol to delete (e.g., `'<user>`)
- `list-of-model`: List of model instances
- `:batch-size` (optional): Batch size (default: 100)
- `:use-transaction` (optional): Use transaction (default: `t`)
- `:on-type-mismatch` (optional): Behavior on type mismatch (`:error` or `:skip`, default: `:error`)
- `:connection` (optional): Explicit database connection

**Returns:**
- Number of deleted records (integer)

### Comparison

| Function | Use Case | Return Value | Cascade | Speed |
|----------|----------|--------------|---------|-------|
| `delete-all` | Delete one by one | List of models | ✅ | Slow |
| `delete-bulk` | Batch DELETE | Count (integer) | ❌ | Fast |

```common-lisp
;; When cascade delete is needed
(let ((deleted-users (delete-all users :cascade t)))
  (format t "Deleted ~A users with related records~%" (length deleted-users)))

;; When only count is needed (fast)
(let ((count (delete-bulk '<user> users)))
  (format t "Deleted ~A records~%" count))
```

### Database Support

| Feature | PostgreSQL | MySQL | SQLite3 |
|---------|-----------|-------|---------|
| DELETE | ✅ | ✅ | ✅ |
| Transaction | ✅ | ✅ | ✅ |
| Batch DELETE | ✅ | ✅ | ✅ |
| IN Clause | ✅ | ✅ | ✅ |

### Tests

Implemented the following tests for each database (PostgreSQL, MySQL, SQLite3):

- Single record deletion
- Multiple record deletion
- Empty list handling
- **Cascade delete (enabled/disabled)**
- Explicit connection specification
- Transaction execution
- Batch size specification
- Type mismatch handling (error/skip)

### Cascade Delete Specification

Cascade delete is **executed only when related objects are already loaded into the instance**.

This approach:
- Prevents unexpected data deletion
- Allows users to control deletion by explicitly loading related data

```common-lisp
;; Cascade delete example
(let ((customer (first (find-by '<customer> :id 1))))
  ;; Pre-load related orders
  (setf (ref customer :orders)
        (find-by '<order> :customer-id (ref customer :id)))

  ;; Now orders will also be cascade deleted
  (delete-all (list customer) :cascade t))
```

### Breaking Changes

None

### Future Enhancements

- Support for `on-missing-id` parameter (handling instances with nil id)
- Addition of `missing-id-error` condition
