### PR TITLE
Add default application/json header to <rest-controller>

### DIFF
--- a/src/controller/base-controller.lisp
+++ b/src/controller/base-controller.lisp
@@ -95,6 +95,16 @@
              :documentation "Response data for REST API"))
   (:documentation "Controller class for REST API endpoints that return structured data."))
 
+(defmethod initialize-instance :after ((c <rest-controller>) &rest initargs)
+  "Set default content-type header to application/json after initialization.
+
+   @param c [<rest-controller>] Controller instance being initialized
+   @param initargs [list] Initialization arguments (ignored)
+   "
+  (declare (ignore initargs))
+  (let ((header (header c)))
+    (setf (slot-value c 'header) (append header '(:content-type "application/json")))))
+
 
 (defmethod param ((controller <base-controller>) key)
   "Get a parameter value from the controller's params hash table.


### PR DESCRIPTION
- Add initialize-instance :after method for <rest-controller>
- Set Content-Type: application/json as default header
- Follows REST API best practices and maintains consistency with <web-controller>

fix: #122 
