### PR TITLE
Add query-builder for Dynamic Query Construction

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -15,6 +15,7 @@
                #:clails-test/model/impl/postgresql
                #:clails-test/model/connection
                #:clails-test/model/query
+               #:clails-test/model/query-builder
                #:clails-test/model/query/sqlite3
                #:clails-test/model/query/mysql
                #:clails-test/model/query/postgresql

--- a/document/model.md
+++ b/document/model.md
@@ -368,6 +368,145 @@ Use the `query` function to build queries.
      (:= (:user :status) "pending"))
 ```
 
+### Dynamic Query Construction (query-builder)
+
+While the `query` macro is suitable for static query definitions, use the `query-builder` function when you need to construct queries dynamically at runtime.
+
+#### Basic Usage
+
+```common-lisp
+;; Create a query instance with query-builder
+(defvar *q* (query-builder '<user> :as :user))
+
+;; Build the query with set-* functions
+(set-columns *q* '((user :id :name :email)))
+(set-where *q* '(:= (:user :status) :status))
+(set-order-by *q* '((:user :created-at :desc)))
+(set-limit *q* 10)
+
+;; Execute with execute-query
+(execute-query *q* '(:status "active"))
+```
+
+#### Setter Functions
+
+All setter functions **replace** the existing content and return the query instance itself for method chaining.
+
+- `set-columns` - Set columns to SELECT
+- `set-joins` - Set JOIN clauses
+- `set-where` - Set WHERE clause (nil to remove)
+- `set-order-by` - Set ORDER BY clause
+- `set-limit` - Set LIMIT clause
+- `set-offset` - Set OFFSET clause
+
+```common-lisp
+;; Method chaining example
+(execute-query
+  (set-limit
+    (set-offset
+      (set-columns (query-builder '<user> :as :user)
+                   '((user :id :name)))
+      10)
+    20)
+  '())
+```
+
+#### Dynamic Column Selection
+
+```common-lisp
+(defun search-users (search-column keyword)
+  "Search users in the specified column"
+  (let ((q (query-builder '<user> :as :user)))
+    ;; Specify column determined at runtime
+    (set-columns q `((user :id ,search-column)))
+    (set-where q `(:like (:user ,search-column) :keyword))
+    (execute-query q (list :keyword (format nil "%~A%" keyword)))))
+
+;; Usage examples
+(search-users :name "John")    ; Search in name column
+(search-users :email "example") ; Search in email column
+```
+
+#### Dynamic WHERE Clause Construction
+
+```common-lisp
+(defun find-users (params)
+  "Dynamically add search conditions based on parameters"
+  (let ((q (query-builder '<user> :as :user))
+        (conditions nil))
+    (set-columns q '((user :id :name :email :status)))
+    
+    ;; Dynamically add conditions
+    (when (getf params :status)
+      (push '(:= (:user :status) :status) conditions))
+    
+    (when (getf params :min-age)
+      (push '(:>= (:user :age) :min-age) conditions))
+    
+    (when (getf params :keyword)
+      (push '(:or
+              (:like (:user :name) :keyword)
+              (:like (:user :email) :keyword))
+            conditions))
+    
+    ;; Combine conditions with AND
+    (when conditions
+      (set-where q `(:and ,@(nreverse conditions))))
+    
+    (execute-query q params)))
+
+;; Usage examples
+(find-users '(:status "active" :min-age 20))
+(find-users '(:keyword "%test%"))
+(find-users '(:status "active" :keyword "%admin%"))
+```
+
+#### Dynamic Sort Order
+
+```common-lisp
+(defun list-users (sort-by sort-order)
+  "Change sort order dynamically"
+  (let ((q (query-builder '<user> :as :user)))
+    (set-columns q '((user :id :name :created-at)))
+    ;; Determine sort order at runtime
+    (set-order-by q `((:user ,sort-by ,sort-order)))
+    (execute-query q '())))
+
+;; Usage examples
+(list-users :name :asc)        ; Ascending by name
+(list-users :created-at :desc) ; Descending by created_at
+```
+
+#### Inspecting Generated SQL
+
+```common-lisp
+;; Check via logs (set LOG_LEVEL=sql:debug)
+(execute-query q params)
+
+;; Check directly with generate-query
+(let ((q (query-builder '<user> :as :user)))
+  (set-columns q '((user :id :name)))
+  (set-where q '(:= (:user :status) :status))
+  (multiple-value-bind (sql params)
+      (generate-query q '(:status "active"))
+    (format t "SQL: ~A~%" sql)
+    (format t "Params: ~S~%" params)))
+;; => SQL: SELECT USER.ID as "USER.ID", USER.NAME as "USER.NAME" FROM users as USER WHERE USER.STATUS = ?
+;; => Params: ("active")
+```
+
+#### When to Use query Macro vs query-builder
+
+- **query macro**: When you need static, type-safe queries (recommended)
+  - Query structure is determined at compile time
+  - Want IDE support (completion, error detection)
+  - Best performance
+
+- **query-builder**: When you need dynamic query construction
+  - Change search conditions based on user input
+  - Determine columns or sort order at runtime
+  - Build queries with complex conditional logic
+
 ---
 
 ## 6. JOIN Queries

--- a/document/model_ja.md
+++ b/document/model_ja.md
@@ -397,6 +397,145 @@ YYYYmmdd-HHMMSS-description.lisp
                   (:user :name)))
 ```
 
+### 動的なクエリ構築（query-builder）
+
+`query` マクロは静的なクエリ定義に適していますが、実行時にクエリを動的に構築したい場合は `query-builder` 関数を使用します。
+
+#### 基本的な使い方
+
+```common-lisp
+;; query-builder でクエリインスタンスを作成
+(defvar *q* (query-builder '<user> :as :user))
+
+;; set-* 関数でクエリを構築
+(set-columns *q* '((user :id :name :email)))
+(set-where *q* '(:= (:user :status) :status))
+(set-order-by *q* '((:user :created-at :desc)))
+(set-limit *q* 10)
+
+;; execute-query で実行
+(execute-query *q* '(:status "active"))
+```
+
+#### setter 関数
+
+すべての setter 関数は、設定されている内容を**置き換え**ます。また、メソッドチェーンのためにクエリインスタンス自身を返します。
+
+- `set-columns` - SELECT するカラムを設定
+- `set-joins` - JOIN 句を設定
+- `set-where` - WHERE 句を設定（nil で削除）
+- `set-order-by` - ORDER BY 句を設定
+- `set-limit` - LIMIT 句を設定
+- `set-offset` - OFFSET 句を設定
+
+```common-lisp
+;; メソッドチェーンの例
+(execute-query
+  (set-limit
+    (set-offset
+      (set-columns (query-builder '<user> :as :user)
+                   '((user :id :name)))
+      10)
+    20)
+  '())
+```
+
+#### 動的なカラム選択
+
+```common-lisp
+(defun search-users (search-column keyword)
+  "指定されたカラムでユーザーを検索"
+  (let ((q (query-builder '<user> :as :user)))
+    ;; 実行時に決まるカラムを指定
+    (set-columns q `((user :id ,search-column)))
+    (set-where q `(:like (:user ,search-column) :keyword))
+    (execute-query q (list :keyword (format nil "%~A%" keyword)))))
+
+;; 使用例
+(search-users :name "John")    ; name カラムで検索
+(search-users :email "example") ; email カラムで検索
+```
+
+#### 動的な WHERE 句の構築
+
+```common-lisp
+(defun find-users (params)
+  "パラメータに応じて動的に検索条件を追加"
+  (let ((q (query-builder '<user> :as :user))
+        (conditions nil))
+    (set-columns q '((user :id :name :email :status)))
+    
+    ;; 条件を動的に追加
+    (when (getf params :status)
+      (push '(:= (:user :status) :status) conditions))
+    
+    (when (getf params :min-age)
+      (push '(:>= (:user :age) :min-age) conditions))
+    
+    (when (getf params :keyword)
+      (push '(:or
+              (:like (:user :name) :keyword)
+              (:like (:user :email) :keyword))
+            conditions))
+    
+    ;; 条件を AND で結合
+    (when conditions
+      (set-where q `(:and ,@(nreverse conditions))))
+    
+    (execute-query q params)))
+
+;; 使用例
+(find-users '(:status "active" :min-age 20))
+(find-users '(:keyword "%test%"))
+(find-users '(:status "active" :keyword "%admin%"))
+```
+
+#### 動的なソート順
+
+```common-lisp
+(defun list-users (sort-by sort-order)
+  "ソート順を動的に変更"
+  (let ((q (query-builder '<user> :as :user)))
+    (set-columns q '((user :id :name :created-at)))
+    ;; 実行時にソート順を決定
+    (set-order-by q `((:user ,sort-by ,sort-order)))
+    (execute-query q '())))
+
+;; 使用例
+(list-users :name :asc)        ; 名前の昇順
+(list-users :created-at :desc) ; 作成日時の降順
+```
+
+#### 生成される SQL の確認
+
+```common-lisp
+;; ログで確認（LOG_LEVEL=sql:debug を設定）
+(execute-query q params)
+
+;; generate-query で直接確認
+(let ((q (query-builder '<user> :as :user)))
+  (set-columns q '((user :id :name)))
+  (set-where q '(:= (:user :status) :status))
+  (multiple-value-bind (sql params)
+      (generate-query q '(:status "active"))
+    (format t "SQL: ~A~%" sql)
+    (format t "Params: ~S~%" params)))
+;; => SQL: SELECT USER.ID as "USER.ID", USER.NAME as "USER.NAME" FROM users as USER WHERE USER.STATUS = ?
+;; => Params: ("active")
+```
+
+#### query マクロと query-builder の使い分け
+
+- **query マクロ**: 静的で型安全なクエリが必要な場合（推奨）
+  - クエリの構造がコンパイル時に確定している
+  - IDE のサポート（補完、エラー検出）を受けたい
+  - 最もパフォーマンスが良い
+
+- **query-builder**: 動的なクエリ構築が必要な場合
+  - 検索条件をユーザー入力に応じて変更
+  - カラムやソート順を実行時に決定
+  - 複雑な条件分岐でクエリを組み立てる
+
 ---
 
 ## 6. JOIN を含むクエリの書き方

--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -39,7 +39,15 @@
                 #:prepare)
   (:export #:<query>
            #:query
+           #:query-builder
+           #:set-columns
+           #:set-joins
+           #:set-where
+           #:set-order-by
+           #:set-limit
+           #:set-offset
            #:execute-query
+           #:generate-query
            #:save
            #:get-last-id-impl
            #:make-record
@@ -106,10 +114,10 @@
 
 (defmethod execute-query ((query <query>) named-values &key connection)
   "Execute the query and return model instances.
-   
+
    Generates SQL from the query specification, executes it against the database,
    and builds model instances from the results, including nested relations.
-   
+
    @param query [<query>] Query specification
    @param named-values [plist] Named parameter values for the query
    @param connection [dbi:<dbi-connection>] Optional database connection to use
@@ -130,10 +138,10 @@
 
 (defmethod save ((inst <base-model>) &key connection)
   "Save model instance to the database.
-   
+
    Validates the instance, then either updates (if ID exists and dirty)
    or inserts (if no ID). Clears dirty flags on success.
-   
+
    @param inst [<base-model>] Model instance to save
    @param connection [dbi:<dbi-connection>] Optional database connection to use
    @return [<base-model>] The saved model instance
@@ -158,9 +166,9 @@
 
 (defgeneric get-last-id-impl (database-type connection)
   (:documentation "Get the last inserted ID for the specified database type.
-   
+
    Implementation must be provided for each database type.
-   
+
    @param database-type [<database-type>] Database type instance
    @param connection [dbi:<dbi-connection>] Database connection
    @return [integer] Last inserted ID
@@ -169,11 +177,11 @@
 
 (defun make-record (model-name &rest values)
   "Create a new model instance with the given attribute values.
-   
+
    @param model-name [symbol] Model class name (e.g., <todo>)
    @param values [plist] Property list of attribute key-value pairs
    @return [<base-model>] New model instance
-   
+
    Example:
    (let ((inst (make-record '<todo> :title \"create new project\" :done nil)))
      (save inst))
@@ -186,7 +194,7 @@
 
 (defgeneric destroy (instance &key cascade)
   (:documentation "Delete record from the database.
-   
+
    @param instance [<base-model>] Model instance to delete
    @param cascade [boolean] Whether to cascade delete to related records
    @return [integer] Number of rows deleted
@@ -194,10 +202,10 @@
 
 (defmethod destroy ((inst <base-model>) &key cascade)
   "Delete a single model instance from the database.
-   
+
    If cascade is true, also deletes related :has-many records.
    Sets the instance to frozen after deletion.
-   
+
    @param inst [<base-model>] Model instance to delete
    @param cascade [boolean] If T, cascade delete to :has-many relations
    @return [integer] Number of rows deleted (0 if frozen, 1 otherwise)
@@ -231,10 +239,10 @@
 
 (defmethod destroy ((insts list) &key cascade)
   "Delete multiple model instances from the database.
-   
+
    If cascade is true, also deletes related :has-many records for each instance.
    Sets all instances to frozen after deletion.
-   
+
    @param insts [list] List of <base-model> instances to delete
    @param cascade [boolean] If T, cascade delete to :has-many relations
    @return [integer] Number of rows deleted
@@ -281,10 +289,10 @@
 
 (defmacro query (model &key as columns joins where order-by limit offset)
   "Create a query builder instance for the specified model.
-   
+
    Provides a DSL for constructing SQL queries with support for joins,
    where clauses, ordering, and pagination.
-   
+
    @param model [symbol] Model class name (e.g., <blog>)
    @param as [keyword] Required alias for the model (e.g., :blog)
    @param columns [list] List of column specifications (e.g., ((blog :id :title) (user :name)))
@@ -295,7 +303,7 @@
    @param offset [integer] OFFSET value
    @return [<query>] Query builder instance
    @condition error Signaled when :as is missing or not a keyword
-   
+
    Example:
    (query <blog>
      :as :blog
@@ -339,6 +347,153 @@
                     :offset ',offset)))
 
 
+(defun query-builder (model &key as)
+  "Create a query builder instance for dynamic query construction.
+
+   Unlike the query macro, this function allows runtime specification of
+   query parameters, enabling dynamic query construction.
+
+   @param model [symbol] Model class name (e.g., <blog>)
+   @param as [keyword] Alias for the model (e.g., :blog)
+   @return [<query>] Query builder instance
+   @condition error Signaled when :as is not provided or not a keyword
+
+   Example:
+   (let ((q (query-builder '<blog> :as :blog)))
+     (set-columns q '((blog :id :title)))
+     (set-where q '(:= (:blog :status) :status))
+     (execute-query q '(:status \"published\")))
+   "
+  (unless as
+    (error ":as keyword is required for query-builder."))
+  (unless (keywordp as)
+    (error "The value for :as must be a keyword (e.g., :blog)."))
+
+  (make-instance '<query>
+                 :model model
+                 :alias as))
+
+
+(defun set-columns (query columns)
+  "Set the columns to select in the query.
+
+   Replaces any previously set columns.
+
+   @param query [<query>] Query builder instance
+   @param columns [list] List of column specifications in grouped format
+                         (e.g., ((blog :id :title) (account :name)))
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-columns q '((blog :id :title :content)))
+   "
+  (labels ((expand-columns (grouped-columns)
+             (mapcan #'(lambda (group)
+                         (let ((alias (car group))
+                               (column-names (cdr group)))
+                           (mapcar #'(lambda (column-name)
+                                       (list alias column-name))
+                                   column-names)))
+                     grouped-columns)))
+    (setf (slot-value query 'columns) (expand-columns columns))
+    query))
+
+
+(defun set-joins (query joins)
+  "Set the JOIN clauses in the query.
+
+   Replaces any previously set joins.
+
+   @param query [<query>] Query builder instance
+   @param joins [list] List of join specifications
+                       (e.g., ((:inner-join :account) (:left-join :comments :through :account)))
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-joins q '((:inner-join :account)))
+   "
+  (labels ((expand-joins (joins-list)
+             (mapcar #'(lambda (join-spec)
+                         (destructuring-bind (join-type relation &key through) join-spec
+                           (make-instance '<join-query>
+                                          :join-type join-type
+                                          :relation relation
+                                          :through through)))
+                     joins-list)))
+    (setf (slot-value query 'joins) (expand-joins joins))
+    ;; Rebuild alias map after changing joins
+    (build-alias-map query)
+    query))
+
+
+(defun set-where (query where-clause)
+  "Set the WHERE clause in the query.
+
+   Replaces any previously set WHERE clause.
+
+   @param query [<query>] Query builder instance
+   @param where-clause [list] WHERE clause expression (nil to remove WHERE clause)
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-where q '(:and (:= (:blog :status) :status)
+                       (:> (:blog :star) :min-star)))
+   "
+  (setf (slot-value query 'where) where-clause)
+  query)
+
+
+(defun set-order-by (query order-by)
+  "Set the ORDER BY clause in the query.
+
+   Replaces any previously set ORDER BY clause.
+
+   @param query [<query>] Query builder instance
+   @param order-by [list] Order specifications
+                          (e.g., (((:blog :created-at :desc) (:blog :id :asc))))
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-order-by q '(((:blog :star :desc) (:blog :id :asc))))
+   "
+  (setf (slot-value query 'order-by) order-by)
+  query)
+
+
+(defun set-limit (query limit)
+  "Set the LIMIT clause in the query.
+
+   Replaces any previously set LIMIT.
+
+   @param query [<query>] Query builder instance
+   @param limit [integer|keyword|nil] LIMIT value, parameter keyword, or nil to remove
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-limit q 10)
+   (set-limit q :limit-param)
+   "
+  (setf (slot-value query 'limit) limit)
+  query)
+
+
+(defun set-offset (query offset)
+  "Set the OFFSET clause in the query.
+
+   Replaces any previously set OFFSET.
+
+   @param query [<query>] Query builder instance
+   @param offset [integer|keyword|nil] OFFSET value, parameter keyword, or nil to remove
+   @return [<query>] The query instance (for method chaining)
+
+   Example:
+   (set-offset q 20)
+   (set-offset q :offset-param)
+   "
+  (setf (slot-value query 'offset) offset)
+  query)
+
+
 ;;;; ========================================
 ;;;; internals
 
@@ -347,10 +502,10 @@
 
 (defmethod initialize-instance :after ((q <query>) &rest initargs)
   "Initialize query instance after creation.
-   
+
    Sets up base model instance, assigns default alias if not provided,
    and builds the alias-to-model mapping.
-   
+
    @param q [<query>] Query instance being initialized
    @param initargs [list] Initialization arguments (ignored)
    "
@@ -373,10 +528,10 @@
 
 (defmethod build-alias-map ((query <query>))
   "Build mapping from aliases to model classes.
-   
+
    Resolves model classes for all aliases (base and joined) by looking up
    relation information in the model metadata.
-   
+
    @param query [<query>] Query instance
    @condition error Signaled when source alias or relation cannot be resolved
    "
@@ -404,10 +559,10 @@
 
 (defmethod generate-query ((query <query>) &optional named-values)
   "Generate SQL query and parameters from query specification.
-   
+
    Constructs SELECT statement with joins, where clause, order by, limit, and offset.
    Handles dynamic IN clause expansion for parameterized queries.
-   
+
    @param query [<query>] Query specification
    @param named-values [plist] Named parameter values
    @return [string] SQL query string
@@ -473,7 +628,7 @@
 
 (defmethod resolve-joins ((query <query>))
   "Generate JOIN clauses for the query.
-   
+
    @param query [<query>] Query instance
    @return [list] List of JOIN SQL strings
    "
@@ -488,10 +643,10 @@
 
 (defmethod generate-query-columns ((query <query>) alias->model)
   "Generate list of columns to select.
-   
+
    If columns are explicitly specified, returns them. Otherwise, returns
    all columns from all models in the query.
-   
+
    @param query [<query>] Query instance
    @param alias->model [hash-table] Mapping from aliases to model classes
    @return [list] List of column pairs (alias column-name)
@@ -507,9 +662,9 @@
 
 (defmethod generate-join-sql ((join-obj <join-query>) base-model-alias alias->model)
   "Generate SQL JOIN clause for a single join specification.
-   
+
    Constructs INNER JOIN or LEFT JOIN with ON clause based on relation metadata.
-   
+
    @param join-obj [<join-query>] Join specification
    @param base-model-alias [keyword] Base model alias
    @param alias->model [hash-table] Mapping from aliases to model classes
@@ -582,10 +737,10 @@
 
 (defun parse-where-claude (where)
   "Parse WHERE clause expression tree into SQL.
-   
+
    Supports operators: :=, :<, :<=, :>, :>=, :<>, :!=, :like, :not-like,
    :between, :not-between, :in, :not-in, :null, :not-null, :and, :or.
-   
+
    @param where [list] WHERE clause expression (nil for no where clause)
    @return [string] SQL WHERE clause string
    @return [list] List of parameter keywords
@@ -633,7 +788,7 @@
 
 (defun parse-in-clause (op exp)
   "Parse IN clause with static list of values.
-   
+
    @param op [string] Operator (\"IN\" or \"NOT IN\")
    @param exp [list] Expression (column-spec values-list)
    @return [string] SQL clause string
@@ -665,9 +820,9 @@
 
 (defun parse-in-dynamic (op exp)
   "Parse IN clause with dynamic parameterized values.
-   
+
    Creates placeholder for later expansion with actual parameter values.
-   
+
    @param op [string] Operator (\"IN\" or \"NOT IN\")
    @param exp [list] Expression (column-spec param-keyword)
    @return [string] Placeholder string for later replacement
@@ -684,7 +839,7 @@
 
 (defun parse-between-clause (op exp)
   "Parse BETWEEN clause.
-   
+
    @param op [string] Operator (\"BETWEEN\" or \"NOT BETWEEN\")
    @param exp [list] Expression (column-spec value1 value2)
    @return [string] SQL BETWEEN clause
@@ -710,7 +865,7 @@
 ;; TODO: rename
 (defun parse-exp2 (op exp)
   "Parse binary comparison expression.
-   
+
    @param op [keyword|string] Operator (:=, :<, :>, etc. or \"LIKE\", \"NOT LIKE\")
    @param exp [list] Expression (left-operand right-operand)
    @return [string] SQL comparison expression
@@ -734,7 +889,7 @@
 ;; TODO: rename
 (defun parse-null2 (op exp)
   "Parse NULL check expression.
-   
+
    @param op [keyword] Operator (:null or :not-null)
    @param exp [list] Expression (column-spec)
    @return [string] SQL NULL check (\"IS NULL\" or \"IS NOT NULL\")
@@ -755,7 +910,7 @@
 ;; TODO: rename
 (defun lexer2 (param)
   "Convert parameter to SQL representation.
-   
+
    @param param [list] Column pair (alias column-name)
    @param param [keyword] Parameter keyword (becomes \"?\")
    @param param [string] String literal (quoted)
@@ -784,7 +939,7 @@
 
 (defun column-pair-to-name (pair &optional as)
   "Convert column pair to SQL column name.
-   
+
    @param pair [list] Column pair (alias column-name)
    @param as [boolean] If true, includes AS clause for aliasing
    @return [string] SQL column reference (e.g., \"BLOG.TITLE\" or \"BLOG.TITLE as \\\"BLOG.TITLE\\\"\")
@@ -795,12 +950,12 @@
 
 (defun generate-order-by (params &optional order)
   "Generate ORDER BY clause from parameters.
-   
+
    @param params [list] List of order specs ((:alias :column [:ASC|:DESC]) ...)
    @param order [list] Accumulator for recursion (internal use)
    @return [list] List of ORDER BY clause strings
    @condition error Signaled for invalid order spec format or sort direction
-   
+
    Example input: ((:blog :star :desc) (:blog :id))
    Example output: (\"BLOG.STAR DESC\" \"BLOG.ID\")
    "
@@ -825,7 +980,7 @@
 ;; TODO: In the future, refactor this to use OFFSET/FETCH depending on the database implementation.
 (defun generate-offset (offset)
   "Generate OFFSET clause specification.
-   
+
    @param offset [nil] No offset
    @param offset [keyword] Parameter keyword for offset value
    @param offset [integer] Literal offset value
@@ -843,7 +998,7 @@
 
 (defun generate-limit (limit)
   "Generate LIMIT clause specification.
-   
+
    @param limit [nil] No limit
    @param limit [keyword] Parameter keyword for limit value
    @param limit [integer] Literal limit value
@@ -862,7 +1017,7 @@
 
 (defun generate-values (named-params named-values)
   "Extract parameter values in order from named values plist.
-   
+
    @param named-params [list] List of parameter keywords in order (e.g., (:start-date :end-date :start-date))
    @param named-values [plist] Property list of parameter values (e.g., (:start-date \"2025-01-01\" :end-date \"2025-12-31\"))
    @return [list] List of values in parameter order (e.g., (\"2025-01-01\" \"2025-12-31\" \"2025-01-01\"))
@@ -950,7 +1105,7 @@
 
 (defun get-last-id (connection)
   "Get the last inserted ID from the database.
-   
+
    @param connection [dbi:<dbi-connection>] Database connection
    @return [integer] Last inserted ID
    "
@@ -959,11 +1114,11 @@
 
 (defun update1 (inst &key connection)
   "Update a model instance in the database.
-   
+
    Only updates columns marked as dirty. Automatically updates :updated-at
    and version column (if configured). Uses optimistic locking when version
    column is specified.
-   
+
    @param inst [<base-model>] Model instance to update
    @param connection [connection] Optional database connection
    @return [integer] Number of rows updated (0 if version mismatch, 1 otherwise)
@@ -1028,9 +1183,9 @@
 
 (defun convert-cl-db-values (params inst)
   "Convert Common Lisp values to database values.
-   
+
    Applies cl-db-fn conversion function for each column.
-   
+
    @param params [plist] Parameter values by column name
    @param inst [<base-model>] Model instance
    @return [list] List of converted values
@@ -1047,9 +1202,9 @@
 
 (defun make-record-from (model-name &rest db-values)
   "Create model instance from database row values.
-   
+
    Applies db-cl-fn conversion for each column and clears dirty flags.
-   
+
    @param model-name [symbol] Model class name
    @param db-values [plist] Database values by column keyword
    @return [<base-model>] Model instance with values set and dirty flags cleared
@@ -1066,10 +1221,10 @@
 
 (defun split-db-column-name (keyword-name)
   "Split database column keyword into alias and column name.
-   
+
    Splits a keyword like :|TABLE.COLUMN| into two keywords, :TABLE and :COLUMN.
    The keyword comes from the database driver.
-   
+
    @param keyword-name [keyword] Database column keyword in format :|ALIAS.COLUMN|
    @return [keyword] Table alias keyword
    @return [keyword] Column name keyword
@@ -1084,10 +1239,10 @@
 
 (defun group-row-data-by-alias (row-plist)
   "Group flat database result row by table alias.
-   
+
    Groups a flat plist of results from the DB into a hash table where keys are
    table aliases and values are plists of column data for that alias.
-   
+
    @param row-plist [plist] Flat result row from database
    @return [hash-table] Hash table with aliases as keys and column data plists as values
    "
@@ -1104,10 +1259,10 @@
 
 (defun hydrate-instance (model-class data-plist record-cache)
   "Create or retrieve cached model instance from data.
-   
+
    Creates a model instance from a plist of data, or retrieves it from cache if it
    has already been created for the same ID.
-   
+
    @param model-class [symbol] Model class name
    @param data-plist [plist] Column data for the instance
    @param record-cache [hash-table] Cache of instances by model class and ID
@@ -1126,10 +1281,10 @@
 
 (defun hydrate-instances-for-row (grouped-data alias->model record-cache)
   "Create or retrieve model instances for all aliases in a result row.
-   
+
    For a single result row (grouped by alias), creates or retrieves all
    corresponding model instances.
-   
+
    @param grouped-data [hash-table] Row data grouped by alias
    @param alias->model [hash-table] Mapping from aliases to model classes
    @param record-cache [hash-table] Cache of instances
@@ -1176,10 +1331,10 @@
 
 (defun finalize-has-many-relations (instances)
   "Initialize unbound :has-many relation slots to NIL.
-   
+
    Ensures that for a list of instances, any :has-many relation slots that were not
    populated during result processing are initialized to NIL instead of being unbound.
-   
+
    @param instances [list] List of model instances
    @return [list] The same list of instances
    "
@@ -1199,10 +1354,10 @@
 
 (defun build-model-instances (query result)
   "Process database result set into graph of nested model instances.
-   
+
    Processes a raw database result set for a given <query> object and constructs
    a graph of nested model instances with relations properly linked.
-   
+
    @param query [<query>] Query specification
    @param result [list] Raw database result set (list of plists)
    @return [list] List of unique main model instances with relations populated

--- a/test/model/query-builder.lisp
+++ b/test/model/query-builder.lisp
@@ -1,0 +1,231 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/query-builder
+  (:use #:cl
+        #:rove
+        #:clails/model/query)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/base-model
+                #:<base-model>
+                #:defmodel
+                #:ref))
+
+(defpackage #:clails-test/model/db
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-column
+                #:add-index
+                #:drop-table
+                #:drop-column
+                #:drop-index))
+(in-package #:clails-test/model/query-builder)
+
+(setup
+  ;; clear table-information
+  (clrhash clails/model/base-model::*table-information*)
+  ;; define models
+  (defmodel <todo> (<base-model>)
+    (:table "todo"))
+
+  ;; Enable SQL logging
+  ;(setf clails/logger:*log-config* '((:sql :level :debug)))
+  (clails/logger:register-logger :sql :level :debug :appender (clails/logger:make-console-appender :formatter (make-instance 'clails/logger:<text-formatter>)))
+  
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0001" "/app/test/data/0001-migration-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (clails/model/migration::db-create)
+  (clails/model/migration::db-migrate)
+  (clails/model/connection::with-db-connection-direct (connection)
+    (dbi-cp:do-sql connection "delete from todo")
+    (dbi-cp:do-sql connection "insert into todo (created_at, updated_at, title, done, done_at) values ('2024-01-01 00:00:00', '2024-01-02 13:00:00', 'create program', true, '2024-01-02 13:00:00')")
+    (dbi-cp:do-sql connection "insert into todo (created_at, updated_at, title, done, done_at) values ('2024-01-01 00:00:01', '2024-01-02 13:00:00', 'create pull request', false, null)")
+    (dbi-cp:do-sql connection "insert into todo (created_at, updated_at, title, done, done_at) values ('2024-01-01 00:00:02', '2024-01-02 13:00:01', 'merge pr', false, null)"))
+  (clails/model/connection:startup-connection-pool)
+  (clails/model/base-model:initialize-table-information))
+
+(teardown
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (clails/model/connection:shutdown-connection-pool))
+
+(deftest test-query-builder-creation
+  (testing "Create query-builder instance"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (ok (typep q '<query>)))))
+
+(deftest test-query-builder-requires-as
+  (testing "query-builder requires :as parameter"
+    (ok (signals (query-builder '<todo>) 'error))))
+
+(deftest test-set-columns
+  (testing "Set columns in query-builder"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title :done)))
+      (let ((results (execute-query q nil)))
+        (ok (= 3 (length results)))
+        (ok (ref (first results) :id))
+        (ok (ref (first results) :title))
+        (ok (ref (first results) :done))))))
+
+(deftest test-set-columns-multiple-aliases
+  (testing "Set columns from multiple table aliases"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (let ((results (execute-query q nil)))
+        (ok (= 3 (length results)))
+        (ok (ref (first results) :id))
+        (ok (ref (first results) :title))
+        (ng (ref (first results) :done))))))
+
+(deftest test-set-where
+  (testing "Set WHERE clause in query-builder"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title :done)))
+      (set-where q '(:= (:todo :done) :done))
+      (let ((results (execute-query q '(:done 1))))  ; Use 1 for true
+        (ok (= 1 (length results)))
+        (ok (string= "create program" (ref (first results) :title)))
+        (ok (ref (first results) :done))))))
+
+(deftest test-set-where-complex
+  (testing "Set complex WHERE clause with AND/OR"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title :done)))
+      (set-where q '(:and (:= (:todo :done) :done)
+                          (:like (:todo :title) :keyword)))
+      (let ((results (execute-query q '(:done 1 :keyword "%program%"))))  ; Use 1 for true
+        (ok (= 1 (length results)))
+        (ok (string= "create program" (ref (first results) :title)))
+        (ok (ref (first results) :done))))))
+
+(deftest test-set-order-by
+  (testing "Set ORDER BY clause"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-order-by q '((:todo :title :desc)))
+      (let ((results (execute-query q nil)))
+        (ok (= 3 (length results)))
+        (ok (string= "merge pr" (ref (first results) :title)))
+        (ok (string= "create pull request" (ref (second results) :title)))
+        (ok (string= "create program" (ref (third results) :title)))))))
+
+(deftest test-set-limit
+  (testing "Set LIMIT clause with integer"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-order-by q '((:todo :id :asc)))
+      (set-limit q 2)
+      (let ((results (execute-query q nil)))
+        (ok (= 2 (length results)))
+        (ok (string= "create program" (ref (first results) :title)))
+        (ok (string= "create pull request" (ref (second results) :title)))))))
+
+(deftest test-set-limit-parameter
+  (testing "Set LIMIT clause with parameter keyword"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-order-by q '((:todo :id :asc)))
+      (set-limit q :limit-param)
+      (let ((results (execute-query q '(:limit-param 1))))
+        (ok (= 1 (length results)))
+        (ok (string= "create program" (ref (first results) :title)))))))
+
+(deftest test-set-offset
+  (testing "Set OFFSET clause with integer"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-order-by q '((:todo :id :asc)))
+      (set-limit q 10)  ; MySQL requires LIMIT with OFFSET
+      (set-offset q 1)
+      (let ((results (execute-query q nil)))
+        (ok (= 2 (length results)))
+        (ok (string= "create pull request" (ref (first results) :title)))
+        (ok (string= "merge pr" (ref (second results) :title)))))))
+
+(deftest test-set-offset-parameter
+  (testing "Set OFFSET clause with parameter keyword"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-order-by q '((:todo :id :asc)))
+      (set-limit q 10)  ; MySQL requires LIMIT with OFFSET
+      (set-offset q :offset-param)
+      (let ((results (execute-query q '(:offset-param 2))))
+        (ok (= 1 (length results)))
+        (ok (string= "merge pr" (ref (first results) :title)))))))
+
+(deftest test-method-chaining
+  (testing "Method chaining with setter functions"
+    (let* ((q (query-builder '<todo> :as :todo))
+           (result (set-limit (set-offset (set-columns q '((todo :id :title))) 1) 1)))
+      (ok (eq result q))
+      (let ((results (execute-query q nil)))
+        (ok (= 1 (length results)))))))
+
+(deftest test-dynamic-column-selection
+  (testing "Dynamic column selection at runtime"
+    (let ((search-column :title))
+      (let ((q (query-builder '<todo> :as :todo)))
+        (set-columns q `((todo :id ,search-column)))
+        (let ((results (execute-query q nil)))
+          (ok (= 3 (length results)))
+          (ok (ref (first results) :id))
+          (ok (ref (first results) :title))
+          (ng (ref (first results) :done)))))))
+
+(deftest test-dynamic-where-construction
+  (testing "Dynamic WHERE clause construction"
+    (let ((conditions nil))
+      (push '(:= (:todo :done) :done) conditions)
+      (push '(:like (:todo :title) :keyword) conditions)
+      (let ((q (query-builder '<todo> :as :todo)))
+        (set-columns q '((todo :id :title :done)))
+        (set-where q `(:and ,@(nreverse conditions)))
+        (let ((results (execute-query q '(:done 0 :keyword "%pull%"))))  ; Use 0 for false
+          (ok (= 1 (length results)))
+          (ok (string= "create pull request" (ref (first results) :title)))
+          (ng (ref (first results) :done)))))))
+
+(deftest test-replace-columns
+  (testing "set-columns replaces existing columns"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-columns q '((todo :id :done)))  ; Include :id to avoid duplicates
+      (let ((results (execute-query q nil)))
+        (ok (= 3 (length results)))
+        (ok (ref (first results) :id))
+        (ok (ref (first results) :done))
+        ;; title should be nil (not selected)
+        (ng (ref (first results) :title))))))
+
+(deftest test-replace-where
+  (testing "set-where replaces existing WHERE clause"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-where q '(:= (:todo :done) :done))
+      (set-where q '(:like (:todo :title) :keyword))
+      (let ((results (execute-query q '(:keyword "%program%"))))
+        (ok (= 1 (length results)))
+        (ok (string= "create program" (ref (first results) :title)))
+        ;; done column should be nil (not selected)
+        (ng (ref (first results) :done))))))
+
+(deftest test-clear-where
+  (testing "set-where with nil clears WHERE clause"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title)))
+      (set-where q '(:= (:todo :done) :done))
+      (set-where q nil)
+      (let ((results (execute-query q nil)))
+        (ok (= 3 (length results)))
+        ;; done should be nil (not selected)
+        (ng (ref (first results) :done))))))


### PR DESCRIPTION
## Overview
This PR introduces `query-builder` function and related setter functions to enable dynamic query construction at runtime, addressing the limitation that the existing `query` macro only supports static queries determined at compile time.

close: #126 

## Changes
- Implement `query-builder` function to create `<query>` instances programmatically
- Add setter functions: `set-columns`, `set-joins`, `set-where`, `set-order-by`, `set-limit`, `set-offset`
- All setters replace existing values and return the query instance for method chaining
- Export `generate-query` method for SQL inspection
- Add comprehensive unit tests with actual query execution (16 tests, all passing)
- Update documentation (model.md and model_ja.md) with usage examples and best practices

## Use Cases
This feature enables flexible query construction based on runtime conditions, such as:
- Building search forms with optional filters
- Dynamically selecting columns based on user permissions
- Adjusting sort order based on user preferences

