### PR TITLE
Add Query Cache Feature to Improve Performance

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -16,6 +16,7 @@
                #:clails-test/model/connection
                #:clails-test/model/query
                #:clails-test/model/query-builder
+               #:clails-test/model/query-cache
                #:clails-test/model/query/sqlite3
                #:clails-test/model/query/mysql
                #:clails-test/model/query/postgresql

--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -107,7 +107,34 @@
    (inst :type 'clails/model/base-model::<base-model>
          :documentation "Model instance")
    (alias->model :initform (make-hash-table)
-                 :documentation "Hash table mapping alias names to model symbols"))
+                 :documentation "Hash table mapping alias names to model symbols")
+   (query-cache :initform nil
+                :documentation "Cached result of query parsing.
+                                Format: (:sql-template <string>
+                                        :where-params <list>
+                                        :where-columns <list>
+                                        :column-types <list>
+                                        :limit-param <keyword|nil>
+                                        :offset-param <keyword|nil>)
+                                NIL when cache is invalid.
+                                
+                                Example:
+                                (:sql-template \"SELECT BLOG.ID as \\\"BLOG.ID\\\", BLOG.TITLE as \\\"BLOG.TITLE\\\" FROM BLOGS as BLOG WHERE BLOG.STATUS = ? AND BLOG.STAR > ? LIMIT ? OFFSET ?\"
+                                 :where-params (:status :min-star)
+                                 :where-columns ((:blog :status) (:blog :star))
+                                 :column-types (:string :integer)
+                                 :limit-param :limit
+                                 :offset-param :offset)
+                                
+                                With dynamic IN clause:
+                                (:sql-template \"SELECT BLOG.ID as \\\"BLOG.ID\\\" FROM BLOGS as BLOG WHERE __IN_CLAUSE_BLOG_ID_:BLOG-IDS__\"
+                                 :where-params ((:in-expansion \"IN\" \"BLOG.ID\" :blog-ids))
+                                 :where-columns nil
+                                 :column-types nil
+                                 :limit-param nil
+                                 :offset-param nil)")
+   (query-cache-valid-p :initform nil
+                        :documentation "Flag indicating if query-cache is valid."))
   (:documentation "Query builder class for constructing and executing database queries."))
 
 (defclass <join-query> ()
@@ -415,6 +442,7 @@
                                    column-names)))
                      grouped-columns)))
     (setf (slot-value query 'columns) (expand-columns columns))
+    (invalidate-query-cache query)
     query))
 
 
@@ -442,6 +470,7 @@
     (setf (slot-value query 'joins) (expand-joins joins))
     ;; Rebuild alias map after changing joins
     (build-alias-map query)
+    (invalidate-query-cache query)
     query))
 
 
@@ -459,6 +488,7 @@
                        (:> (:blog :star) :min-star)))
    "
   (setf (slot-value query 'where) where-clause)
+  (invalidate-query-cache query)
   query)
 
 
@@ -476,6 +506,7 @@
    (set-order-by q '(((:blog :star :desc) (:blog :id :asc))))
    "
   (setf (slot-value query 'order-by) order-by)
+  (invalidate-query-cache query)
   query)
 
 
@@ -493,6 +524,7 @@
    (set-limit q :limit-param)
    "
   (setf (slot-value query 'limit) limit)
+  (invalidate-query-cache query)
   query)
 
 
@@ -510,11 +542,25 @@
    (set-offset q :offset-param)
    "
   (setf (slot-value query 'offset) offset)
+  (invalidate-query-cache query)
   query)
 
 
 ;;;; ========================================
 ;;;; internals
+
+;;; ----------------------------------------
+;;; cache management
+
+(defun invalidate-query-cache (query)
+  "Invalidate the query cache.
+
+   Called when any part of the query definition is modified.
+
+   @param query [<query>] Query instance
+   "
+  (setf (slot-value query 'query-cache) nil)
+  (setf (slot-value query 'query-cache-valid-p) nil))
 
 ;;; ----------------------------------------
 ;;; instance
@@ -576,11 +622,82 @@
 ;;; ----------------------------------------
 ;;; query
 
+(defun get-or-parse-query (query)
+  "Get cached query parse result or parse and cache it.
+
+   @param query [<query>] Query instance
+   @return [string] SQL template string
+   @return [list] WHERE clause parameter keywords
+   @return [list] WHERE clause column specs
+   @return [list] Column types for parameters
+   @return [keyword|nil] LIMIT parameter keyword
+   @return [keyword|nil] OFFSET parameter keyword
+   "
+  (if (slot-value query 'query-cache-valid-p)
+      ;; Return from cache
+      (let ((cache (slot-value query 'query-cache)))
+        (values (getf cache :sql-template)
+                (getf cache :where-params)
+                (getf cache :where-columns)
+                (getf cache :column-types)
+                (getf cache :limit-param)
+                (getf cache :offset-param)))
+      ;; Parse and cache
+      (let* ((alias->model (slot-value query 'alias->model))
+             (base-alias (slot-value query 'alias))
+             (base-model (slot-value query 'model))
+             (base-table-name (getf (gethash base-model clails/model/base-model::*table-information*) 
+                                    :table-name))
+             (joins (resolve-joins query))
+             (columns (mapcar #'(lambda (c) (column-pair-to-name c T))
+                              (generate-query-columns query alias->model)))
+             (where-parts (multiple-value-list (parse-where-claude (slot-value query 'where))))
+             (order-by (generate-order-by (slot-value query 'order-by)))
+             (offset-spec (generate-offset (slot-value query 'offset)))
+             (limit-spec (generate-limit (slot-value query 'limit)))
+             (lock-clause (slot-value query 'lock-clause))
+             (sql-template (format nil "SELECT ~{~A~^, ~} FROM ~A as ~A~@[ ~A~]~@[ WHERE ~A~]~@[ ORDER BY ~{~A~^, ~}~]~@[ LIMIT ~A~]~@[ OFFSET ~A~]~@[ ~A~]"
+                                   columns
+                                   base-table-name
+                                   (kebab->snake base-alias)
+                                   (format nil "~{~A~^ ~}" joins)
+                                   (first where-parts)
+                                   order-by
+                                   (getf limit-spec :limit)
+                                   (getf offset-spec :offset)
+                                   lock-clause))
+             ;; Build column types list for WHERE clause parameters
+             (column-types (loop for column-spec in (third where-parts)
+                                 collect (when column-spec
+                                          (let* ((model-symbol (gethash (first column-spec) alias->model))
+                                                 (column-keyword (second column-spec)))
+                                            (when model-symbol
+                                              (get-column-type-from-model model-symbol column-keyword)))))))
+        
+        ;; Save to cache
+        (setf (slot-value query 'query-cache)
+              (list :sql-template sql-template
+                    :where-params (second where-parts)
+                    :where-columns (third where-parts)
+                    :column-types column-types
+                    :limit-param (getf limit-spec :keyword)
+                    :offset-param (getf offset-spec :keyword)))
+        (setf (slot-value query 'query-cache-valid-p) t)
+        
+        ;; Return results
+        (values sql-template
+                (second where-parts)
+                (third where-parts)
+                column-types
+                (getf limit-spec :keyword)
+                (getf offset-spec :keyword)))))
+
 (defmethod generate-query ((query <query>) &optional named-values &key (convert-types t))
   "Generate SQL query and parameters from query specification.
 
    Constructs SELECT statement with joins, where clause, order by, limit, and offset.
    Handles dynamic IN clause expansion for parameterized queries.
+   Uses cached parsing results if available.
 
    @param query [<query>] Query specification
    @param named-values [plist] Named parameter values
@@ -588,94 +705,70 @@
    @return [string] SQL query string
    @return [list] List of parameter values
    "
-  (let* ((alias->model (slot-value query 'alias->model))
-         (base-alias (slot-value query 'alias))
-         (base-model (slot-value query 'model))
-         (base-table-name (getf (gethash base-model clails/model/base-model::*table-information*) :table-name)))
-
-    (let* ((joins (resolve-joins query))
-           (columns (mapcar #'(lambda (c) (column-pair-to-name c T))
-                            (generate-query-columns query alias->model)))
-           (where-parts (multiple-value-list (parse-where-claude (slot-value query 'where))))
-           (order-by (generate-order-by (slot-value query 'order-by)))
-           (offset (generate-offset (slot-value query 'offset)))
-           (limit (generate-limit (slot-value query 'limit)))
-           (lock-clause (slot-value query 'lock-clause))
-           (sql-template (format nil "SELECT ~{~A~^, ~} FROM ~A as ~A~@[ ~A~]~@[ WHERE ~A~]~@[ ORDER BY ~{~A~^, ~}~]~@[ LIMIT ~A~]~@[ OFFSET ~A~]~@[ ~A~]"
-                                 columns
-                                 base-table-name
-                                 (kebab->snake base-alias)
-                                 (format nil "~{~A~^ ~}" joins)
-                                 (first where-parts)
-                                 order-by
-                                 (getf limit :limit)
-                                 (getf offset :offset)
-                                 lock-clause))
-           (named-params (append (second where-parts)
-                                          (ensure-list (getf limit :keyword))
-                                          (ensure-list (getf offset :keyword))))
-           (column-specs (third where-parts)))
-
-      (let ((final-sql sql-template)
-            (final-params '())
-            (regular-named-params '())
-            (regular-column-specs '())
-            (where-param-count (length (second where-parts))))
-
-        (loop for param in named-params
-              for param-index from 0
-              do (if (and (listp param) (eq (car param) :in-expansion))
-                     (destructuring-bind (op column-sql keyword) (cdr param)
-                       (let* ((values (getf named-values keyword))
-                              (placeholder (format nil "__IN_CLAUSE_~A_~A__"
-                                                   (cl-ppcre:regex-replace-all "[.:]" column-sql "_")
-                                                   keyword)))
-
-                         (if (null values)
-                             (let ((replacement (if (string= op "IN") "1=0" "1=1")))
-                               (setf final-sql (cl-ppcre:regex-replace-all (cl-ppcre:quote-meta-chars placeholder) final-sql replacement)))
-                             (let* ((question-marks (format nil "(~{?~*~^, ~})" values))
-                                    (replacement (format nil "~A ~A ~A" column-sql op question-marks)))
-                               (setf final-sql (cl-ppcre:regex-replace-all (cl-ppcre:quote-meta-chars placeholder) final-sql replacement))
-                               (appendf final-params values)))))
-                     (progn
-                       (push param regular-named-params)
-                       ;; Only add column spec if this parameter is from WHERE clause
-                       (when (< param-index where-param-count)
-                         (push (nth param-index column-specs) regular-column-specs)))))
-
-        ;; Convert parameter values based on column types
-        (let* ((reversed-params (nreverse regular-named-params))
-               (reversed-specs (nreverse regular-column-specs))
-               ;; Pad column-specs with nil to match params length
-               (padded-specs (append reversed-specs 
-                                    (make-list (- (length reversed-params) 
-                                                 (length reversed-specs)))))
-               (converted-values
-                (if convert-types
-                    (loop for param-key in reversed-params
-                          for column-spec in padded-specs
-                          as value = (getf named-values param-key)
-                          collect
-                          (if column-spec
-                              (let* ((model-symbol (gethash (first column-spec) alias->model))
-                                     (column-keyword (second column-spec))
-                                     (column-type (when model-symbol
-                                                   (get-column-type-from-model model-symbol column-keyword))))
-                                (if column-type
+  (multiple-value-bind (sql-template where-params where-columns column-types limit-param offset-param)
+      (get-or-parse-query query)
+    
+    (let ((final-sql sql-template)
+          (final-params '())
+          (regular-named-params '())
+          (regular-column-types '())
+          (alias->model (slot-value query 'alias->model)))
+      
+      ;; Process WHERE clause parameters (including dynamic IN clause expansion)
+      (loop for param in where-params
+            for param-index from 0
+            do (if (and (listp param) (eq (car param) :in-expansion))
+                   ;; Dynamic IN clause expansion
+                   (destructuring-bind (op column-sql keyword) (cdr param)
+                     (let* ((values (getf named-values keyword))
+                            (placeholder (format nil "__IN_CLAUSE_~A_~A__"
+                                                 (cl-ppcre:regex-replace-all "[.:]" column-sql "_")
+                                                 keyword)))
+                       (if (null values)
+                           (let ((replacement (if (string= op "IN") "1=0" "1=1")))
+                             (setf final-sql (cl-ppcre:regex-replace-all 
+                                              (cl-ppcre:quote-meta-chars placeholder) 
+                                              final-sql 
+                                              replacement)))
+                           (let* ((question-marks (format nil "(~{?~*~^, ~})" values))
+                                  (replacement (format nil "~A ~A ~A" column-sql op question-marks)))
+                             (setf final-sql (cl-ppcre:regex-replace-all 
+                                              (cl-ppcre:quote-meta-chars placeholder) 
+                                              final-sql 
+                                              replacement))
+                             (appendf final-params values)))))
+                   ;; Regular parameter
+                   (progn
+                     (push param regular-named-params)
+                     (push (nth param-index column-types) regular-column-types))))
+      
+      ;; Convert parameter values based on column types
+      (let* ((reversed-params (nreverse regular-named-params))
+             (reversed-types (nreverse regular-column-types))
+             (converted-values
+              (if convert-types
+                  (loop for param-key in reversed-params
+                        for column-type in reversed-types
+                        as value = (getf named-values param-key)
+                        collect (if column-type
                                     (convert-value-by-type value column-type)
                                     value))
-                              value))
-                    (loop for param-key in reversed-params
-                          collect (getf named-values param-key)))))
-          (appendf final-params converted-values))
-
-        ;; for debug
-        (when (log-level-enabled-p :sql :debug)
-          (log.sql (format nil "sql: ~S" sql))
-          (log.sql (format nil "params: ~S" params)))
-
-        (values final-sql final-params)))))
+                  (loop for param-key in reversed-params
+                        collect (getf named-values param-key)))))
+        (appendf final-params converted-values))
+      
+      ;; Add LIMIT/OFFSET parameters
+      (when limit-param
+        (appendf final-params (list (getf named-values limit-param))))
+      (when offset-param
+        (appendf final-params (list (getf named-values offset-param))))
+      
+      ;; For debug
+      (when (log-level-enabled-p :sql :debug)
+        (log.sql (format nil "sql: ~S" final-sql))
+        (log.sql (format nil "params: ~S" final-params)))
+      
+      (values final-sql final-params))))
 
 
 (defmethod resolve-joins ((query <query>))

--- a/test/model/query-cache.lisp
+++ b/test/model/query-cache.lisp
@@ -1,0 +1,272 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/query-cache
+  (:use #:cl
+        #:rove
+        #:clails/model)
+  (:import-from #:clails/model/query
+                #:query
+                #:query-builder
+                #:set-columns
+                #:set-joins
+                #:set-where
+                #:set-order-by
+                #:set-limit
+                #:set-offset
+                #:execute-query
+                #:generate-query)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:get-connection)
+  (:import-from #:clails/model/migration
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/logger
+                #:clear-loggers
+                #:register-logger
+                #:make-console-appender
+                #:<text-formatter>)
+  (:import-from #:clails/util
+                #:env-or-default))
+
+(defpackage #:clails-test/model/db
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-index
+                #:drop-table))
+
+(in-package #:clails-test/model/query-cache)
+
+
+(setup
+  (clear-loggers)
+  (register-logger
+   :sql
+   :appender (make-console-appender
+              :formatter (make-instance '<text-formatter>))
+   :level :trace)
+
+  (clrhash clails/model/base-model::*table-information*)
+  
+  ;; Define test model
+  (defmodel <todo> (<base-model>)
+    (:table "todo"))
+
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0001" "/app/test/data/0001-migration-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (db-create)
+  (db-migrate)
+  (startup-connection-pool)
+  (initialize-table-information)
+  
+  ;; Insert test data
+  (let ((connection (get-connection)))
+    (dbi-cp:execute (dbi-cp:prepare connection "INSERT INTO todo (title, done, done_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
+                    (list "First Task" 1 "2024-01-01 00:00:00" "2024-01-01 00:00:00" "2024-01-01 00:00:00"))
+    (dbi-cp:execute (dbi-cp:prepare connection "INSERT INTO todo (title, done, done_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
+                    (list "Second Task" 0 nil "2024-01-02 00:00:00" "2024-01-02 00:00:00"))
+    (dbi-cp:execute (dbi-cp:prepare connection "INSERT INTO todo (title, done, done_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
+                    (list "Third Task" 1 "2024-01-03 00:00:00" "2024-01-03 00:00:00" "2024-01-03 00:00:00"))))
+
+
+(teardown
+  (shutdown-connection-pool)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+
+;;;; ----------------------------------------
+;;;; Unit Tests
+
+(deftest query-cache-initial-state
+  (testing "Cache is invalid initially"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+(deftest query-cache-generation
+  (testing "Cache is generated on first generate-query call"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; First call - cache should be generated
+      (generate-query q '(:done 1))
+      
+      (ok (not (null (slot-value q 'clails/model/query::query-cache))))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Verify cache structure
+      (let ((cache (slot-value q 'clails/model/query::query-cache)))
+        (ok (getf cache :sql-template))
+        (ok (getf cache :where-params))
+        (ok (getf cache :where-columns))
+        (ok (getf cache :column-types))))))
+
+(deftest query-cache-usage
+  (testing "Cached query is returned on subsequent calls"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      
+      ;; Set a dummy string in cache to verify it's being used
+      (setf (slot-value q 'clails/model/query::query-cache)
+            (list :sql-template "DUMMY SQL TEMPLATE"
+                  :where-params '(:done)
+                  :where-columns '((:todo :done))
+                  :column-types '(:boolean)
+                  :limit-param nil
+                  :offset-param nil))
+      
+      ;; Second call - should use the dummy cache
+      (multiple-value-bind (sql params)
+          (generate-query q '(:done 0))
+        (ok (string= sql "DUMMY SQL TEMPLATE"))
+        (ok (equal params '(0)))))))
+
+(deftest query-cache-invalidation-by-set-columns
+  (testing "Cache is invalidated when set-columns is called"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Call set-columns
+      (set-columns q '((todo :id :title)))
+      
+      ;; Cache should be invalidated
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+(deftest query-cache-invalidation-by-set-where
+  (testing "Cache is invalidated when set-where is called"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-where q '(:= (:todo :done) :done))
+      
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Call set-where
+      (set-where q '(:not-null (:todo :done-at)))
+      
+      ;; Cache should be invalidated
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+(deftest query-cache-invalidation-by-set-order-by
+  (testing "Cache is invalidated when set-order-by is called"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Call set-order-by
+      (set-order-by q '((:todo :id :desc)))
+      
+      ;; Cache should be invalidated
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+(deftest query-cache-invalidation-by-set-limit
+  (testing "Cache is invalidated when set-limit is called"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Call set-limit
+      (set-limit q 10)
+      
+      ;; Cache should be invalidated
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+(deftest query-cache-invalidation-by-set-offset
+  (testing "Cache is invalidated when set-offset is called"
+    (let ((q (query <todo> :as :todo :where (:= (:todo :done) :done))))
+      ;; Generate cache
+      (generate-query q '(:done 1))
+      (ok (slot-value q 'clails/model/query::query-cache-valid-p))
+      
+      ;; Call set-offset
+      (set-offset q 20)
+      
+      ;; Cache should be invalidated
+      (ok (null (slot-value q 'clails/model/query::query-cache)))
+      (ok (null (slot-value q 'clails/model/query::query-cache-valid-p))))))
+
+
+;;;; ----------------------------------------
+;;;; Integration Tests
+
+(deftest query-cache-integration-first-and-second-execution
+  (testing "First and second executions return the same results"
+    (let ((q (query <todo>
+               :as :todo
+               :columns ((todo :id :title :done))
+               :where (:= (:todo :done) :done)
+               :order-by ((:todo :id)))))
+      
+      ;; First execution (no cache)
+      (let ((results1 (execute-query q '(:done 1))))
+        
+        ;; Second execution (with cache)
+        (let ((results2 (execute-query q '(:done 1))))
+          
+          ;; Results should be identical
+          (ok (= (length results1) (length results2)))
+          (ok (= (length results1) 2))
+          
+          ;; Verify first result
+          (ok (string= (ref (first results1) :title) (ref (first results2) :title)))
+          (ok (= (ref (first results1) :done) (ref (first results2) :done))))))))
+
+(deftest query-cache-integration-different-parameters
+  (testing "Different parameters return different results with cache"
+    (let ((q (query <todo>
+               :as :todo
+               :columns ((todo :id :title :done))
+               :where (:= (:todo :done) :done)
+               :order-by ((:todo :id)))))
+      
+      ;; First execution with done=1
+      (let ((results1 (execute-query q '(:done 1))))
+        
+        ;; Second execution with done=0 (cache should be reused, but parameters are different)
+        (let ((results2 (execute-query q '(:done 0))))
+          
+          ;; Results should be different
+          (ok (= (length results1) 2))
+          (ok (= (length results2) 1))
+          
+          (ok (= (ref (first results1) :done) 1))
+          (ok (= (ref (first results2) :done) 0)))))))
+
+(deftest query-cache-integration-query-builder
+  (testing "Query builder with cache works correctly"
+    (let ((q (query-builder '<todo> :as :todo)))
+      (set-columns q '((todo :id :title :done)))
+      (set-where q '(:= (:todo :done) :done))
+      (set-order-by q '((:todo :id)))
+      
+      ;; First execution (no cache)
+      (let ((results1 (execute-query q '(:done 1))))
+        
+        ;; Second execution (with cache)
+        (let ((results2 (execute-query q '(:done 1))))
+          
+          ;; Results should be identical
+          (ok (= (length results1) (length results2)))
+          (ok (= (length results1) 2))
+          
+          ;; All results should have done=1
+          (ok (every #'(lambda (r) (= (ref r :done) 1)) results1))
+          (ok (every #'(lambda (r) (= (ref r :done) 1)) results2)))))))

--- a/test/model/query-cache.lisp
+++ b/test/model/query-cache.lisp
@@ -72,6 +72,9 @@
   
   ;; Insert test data
   (let ((connection (get-connection)))
+    ;; Clear existing data first
+    (dbi-cp:execute (dbi-cp:prepare connection "DELETE FROM todo") '())
+    
     (dbi-cp:execute (dbi-cp:prepare connection "INSERT INTO todo (title, done, done_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
                     (list "First Task" 1 "2024-01-01 00:00:00" "2024-01-01 00:00:00" "2024-01-01 00:00:00"))
     (dbi-cp:execute (dbi-cp:prepare connection "INSERT INTO todo (title, done, done_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)")
@@ -227,7 +230,7 @@
           
           ;; Verify first result
           (ok (string= (ref (first results1) :title) (ref (first results2) :title)))
-          (ok (= (ref (first results1) :done) (ref (first results2) :done))))))))
+          (ok (eq (ref (first results1) :done) (ref (first results2) :done))))))))
 
 (deftest query-cache-integration-different-parameters
   (testing "Different parameters return different results with cache"
@@ -247,8 +250,8 @@
           (ok (= (length results1) 2))
           (ok (= (length results2) 1))
           
-          (ok (= (ref (first results1) :done) 1))
-          (ok (= (ref (first results2) :done) 0)))))))
+          (ok (eq (ref (first results1) :done) T))
+          (ok (eq (ref (first results2) :done) NIL)))))))
 
 (deftest query-cache-integration-query-builder
   (testing "Query builder with cache works correctly"
@@ -267,6 +270,6 @@
           (ok (= (length results1) (length results2)))
           (ok (= (length results1) 2))
           
-          ;; All results should have done=1
-          (ok (every #'(lambda (r) (= (ref r :done) 1)) results1))
-          (ok (every #'(lambda (r) (= (ref r :done) 1)) results2)))))))
+          ;; All results should have done=T
+          (ok (every #'(lambda (r) (eq (ref r :done) T)) results1))
+          (ok (every #'(lambda (r) (eq (ref r :done) T)) results2)))))))


### PR DESCRIPTION
## Overview

This PR implements a caching mechanism for query parsing results in the `<query>` class to optimize the `generate-query` method. The cache stores the entire query parsing result (SQL template, WHERE parameters/column
s, column types, LIMIT/OFFSET parameters) so that parsing only occurs once on the first execution.

## Motivation

Currently, `generate-query` parses the query specification (SELECT, JOIN, WHERE, ORDER BY, LIMIT, OFFSET clauses) every time it's called, even when the query definition hasn't changed. This becomes a performance bott
leneck in scenarios such as:

- Pagination: Same query executed repeatedly with different OFFSET values
- Batch processing: Large number of queries with the same structure
- Complex queries: Multiple JOINs and nested WHERE clauses increase parsing cost

## Changes

### Core Implementation

**`src/model/query.lisp`**
- Added `query-cache` and `query-cache-valid-p` slots to `<query>` class
- Implemented `get-or-parse-query` function to retrieve cached results or parse and cache on first call
- Modified `generate-query` to use cached parsing results
- Updated all setter functions (`set-columns`, `set-joins`, `set-where`, `set-order-by`, `set-limit`, `set-offset`) to invalidate cache when query definition changes
- Added `invalidate-query-cache` function for cache management

### Cache Structure

The cache stores:
- `:sql-template` - Generated SQL string with placeholders for dynamic IN clauses
- `:where-params` - List of WHERE clause parameter keywords
- `:where-columns` - Column specifications for each WHERE parameter
- `:column-types` - **Column type information for parameters** (NEW: eliminates repeated `get-column-type-from-model` calls)
- `:limit-param` - LIMIT parameter keyword (if exists)
- `:offset-param` - OFFSET parameter keyword (if exists)

### Testing

**`test/model/query-cache.lisp`** (NEW)
- Unit tests: Cache generation, usage, and invalidation by setter functions
- Integration tests: Verify identical results between cached and non-cached executions with different parameters

**`clails-test.asd`**
- Added `#:clails-test/model/query-cache` to dependencies

## Design Decisions

### Whole Cache vs Partial Cache

We chose **whole cache approach** (caching entire query parsing result) over partial cache (caching each clause individually) because:

- Simpler implementation and easier maintenance
- Most use cases involve queries that don't change after initial construction
- Even with `query-builder`, changes are rare after construction completes

### Type Information Caching

Column type information is now cached alongside other parsing results, eliminating the need to call `get-column-type-from-model` on every execution. This provides additional performance benefits for type conversion.

## Performance Impact

### Expected Benefits

- **Reduced CPU usage**: Parsing only occurs once per query object
- **Faster query execution**: Especially noticeable with complex WHERE clauses and multiple JOINs
- **Better scalability**: Improved performance for pagination and batch processing

### Memory Impact

Minimal - cache contains only SQL strings and keyword lists. Cache lifetime is tied to query object lifetime.

## Testing

All tests pass including:
- Existing query tests (no breaking changes)
- New query-cache unit tests (6 tests)
- New query-cache integration tests (3 tests)

Run tests with:
```bash
make test
```

## Backward Compatibility

✅ **No breaking changes** - All existing functionality remains unchanged. The cache is transparent to users and automatically managed.

## Related Issues

close: #130
