### PR TITLE
Fix: Apply kebab->snake conversion to table names in add-column operation

### DIFF
--- a/src/model/impl/mysql.lisp
+++ b/src/model/impl/mysql.lisp
@@ -255,7 +255,7 @@
 
 (defun gen-add-column (table columns)
   (format NIL "ALTER TABLE ~A ~{ ADD COLUMN ~A ~^, ~}"
-              table
+              (kebab->snake table)
               (loop for col in columns
                     collect (parse-column col))))
 

--- a/src/model/impl/postgresql.lisp
+++ b/src/model/impl/postgresql.lisp
@@ -277,7 +277,7 @@
 
 (defun gen-add-column (table columns)
   (format NIL "ALTER TABLE ~A ~{ ADD COLUMN ~A ~^, ~}"
-              table
+              (kebab->snake table)
               (loop for col in columns
                     collect (parse-column col))))
 

--- a/src/model/impl/sqlite3.lisp
+++ b/src/model/impl/sqlite3.lisp
@@ -283,7 +283,7 @@
 
 (defun gen-add-column (table columns)
   (format NIL "ALTER TABLE ~A ~{ ADD COLUMN ~A ~^, ~}"
-              table
+              (kebab->snake table)
               (loop for col in columns
                     collect (parse-column col))))
 


### PR DESCRIPTION
This PR fixes a syntax error that occurs when executing add-column on tables with hyphenated names. The issue was caused by gen-add-column functions not applying kebab->snake conversion to table names before generating SQL.

Changes:
- Applied kebab->snake conversion in gen-add-column for MySQL
- Applied kebab->snake conversion in gen-add-column for PostgreSQL
- Applied kebab->snake conversion in gen-add-column for SQLite3

This ensures table names with hyphens are properly converted to snake_case format in the generated ALTER TABLE statements.

fix: #133 