### PR TITLE
Fix: Change defparameter to defvar to prevent configuration reset on reload

### DIFF
--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -50,31 +50,31 @@
   (:documentation "Dummy database type specification for testing."))
 
 
-(defparameter *project-name* ""
+(defvar *project-name* ""
   "Project name. Set in app/config/environment.lisp.")
 
-(defparameter *project-dir* ""
+(defvar *project-dir* ""
   "Project directory. Set at startup.")
 
-(defparameter *project-environment* :develop
+(defvar *project-environment* :develop
   "Specify one of :develop, :test, or :production. Can be overridden in app/config/environment.lisp.")
 
-(defparameter *database-config* nil
+(defvar *database-config* nil
   "Holds database connection information, etc. Set in app/config/database.lisp.")
 
-(defparameter *database-type* nil
+(defvar *database-type* nil
   "Holds an instance of <database-type> to specify the database in use. Set in app/config/database.lisp.")
 
-(defparameter *migration-base-dir* ""
+(defvar *migration-base-dir* ""
   "The base path for directories where migration files are placed. Usually set to *project-dir*. (May be set to a different directory for testing, etc.)")
 
-(defparameter *task-base-dir* ""
+(defvar *task-base-dir* ""
   "The base path for directories where task files are placed. Usually set to *project-dir*. (May be set to a different directory for testing, etc.)")
 
-(defparameter *connection-pool* nil
+(defvar *connection-pool* nil
   "Database connection pool. Created when the application server statts and destroyed when it shuts down.")
 
-(defparameter *routing-tables*
+(defvar *routing-tables*
   '((:path "/"
      :controller "clails/controller/base-controller:<default-controller>"))
   "Application routing table configuration.
@@ -143,13 +143,13 @@
 
    Set in app/config/environment.lisp.")
 
-(defparameter *startup-hooks*
+(defvar *startup-hooks*
   '("clails/model/connection:startup-connection-pool"))
 
-(defparameter *shutdown-hooks*
+(defvar *shutdown-hooks*
   '("clails/model/connection:shutdown-connection-pool"))
 
-(defparameter *default-lock-mode* :for-update
+(defvar *default-lock-mode* :for-update
   "Default lock mode for with-locked-transaction macro.
 
    Possible values:
@@ -162,7 +162,7 @@
 
    This can be overridden in <project>/app/config/environment.lisp")
 
-(defparameter *sqlite3-busy-timeout* 50
+(defvar *sqlite3-busy-timeout* 50
   "SQLite3 busy timeout in milliseconds.
 
    When SQLite3 encounters a locked database, it will wait up to this
@@ -171,7 +171,7 @@
 
    This can be overridden in <project>/app/config/environment.lisp")
 
-(defparameter *sqlite3-lock-retry-count* 3
+(defvar *sqlite3-lock-retry-count* 3
   "Number of retry attempts for SQLite3 locked database errors.
 
    When BEGIN IMMEDIATE fails due to database lock, the transaction
@@ -180,7 +180,7 @@
 
    This can be overridden in <project>/app/config/environment.lisp")
 
-(defparameter *sqlite3-transaction-mode* nil
+(defvar *sqlite3-transaction-mode* nil
   "SQLite3 transaction mode for the current dynamic context.
 
    This is a special variable used to pass the transaction mode
@@ -194,20 +194,20 @@
    This variable is set by with-locked-transaction macro and should not
    be set directly by user code.")
 
-(defparameter *sqlite3-lock-module-loaded* nil
+(defvar *sqlite3-lock-module-loaded* nil
   "Flag indicating whether sqlite3-lock module has been loaded.
 
    Set to T after src/model/impl/sqlite3-lock.lisp is successfully loaded.
    Used to ensure the module is loaded only once.")
 
-(defparameter *table-information-initialized* nil
+(defvar *table-information-initialized* nil
   "Flag indicating whether initialize-table-information has been executed.
 
    Set to T after initialize-table-information completes successfully.
    Used by query macro to determine whether to create actual query instances
    or placeholder instances for lazy initialization.")
 
-(defparameter *query-initialization-callbacks* nil
+(defvar *query-initialization-callbacks* nil
   "List of callback functions to initialize query placeholders.
 
    When query macro is expanded before initialize-table-information is called,

--- a/src/middleware/core.lisp
+++ b/src/middleware/core.lisp
@@ -13,7 +13,7 @@
            #:show-middleware-stack))
 (in-package #:clails/middleware/core)
 
-(defparameter *clails-middleware-stack* (list
+(defvar *clails-middleware-stack* (list
                                           *lack-middleware-transaction*
                                           *lack-middleware-clails-controller*
                                           #'(lambda (app)

--- a/src/middleware/transaction-middleware.lisp
+++ b/src/middleware/transaction-middleware.lisp
@@ -12,7 +12,7 @@
 (in-package #:clails/middleware/transaction-middleware)
 
 
-(defparameter *enable-transaction-middleware* t
+(defvar *enable-transaction-middleware* t
   "Flag to enable/disable transaction middleware.
    
    When T (default), all requests are wrapped in transactions.


### PR DESCRIPTION
## Summary

Fixed an issue where configuration values defined with `defparameter` were reset to their initial values when `<app>` was reloaded during `clails test` comm
and execution.

## Problem

When executing the `clails test` command, the following problem occurred:

1. `clails.boot` loads `<app>` and initializes database configuration
2. During test execution, `<app>` is reloaded because `<app-test>` depends on `<app>`
3. Variables defined with `defparameter` are overwritten with initial values
4. Database configuration is lost or becomes incomplete

The following variables were particularly affected:
- `clails/environment:*database-config*`
- `clails/environment:*database-type*`
- Other application configuration variables

## Changes

### 1. `src/environment.lisp`

Changed variables that application developers are expected to override from `defparameter` to `defvar`:

- `*project-name*`
- `*project-dir*`
- `*project-environment*`
- `*database-config*`
- `*database-type*`
- `*migration-base-dir*`
- `*task-base-dir*`
- `*connection-pool*`
- `*routing-tables*`
- `*startup-hooks*`
- `*shutdown-hooks*`
- `*default-lock-mode*`
- `*sqlite3-busy-timeout*`
- `*sqlite3-lock-retry-count*`
- `*sqlite3-transaction-mode*`
- `*sqlite3-lock-module-loaded*`
- `*table-information-initialized*`
- `*query-initialization-callbacks*`

### 2. `src/middleware/transaction-middleware.lisp`

- Changed `*enable-transaction-middleware*` to `defvar`

### 3. `src/middleware/core.lisp`

- Changed `*clails-middleware-stack*` to `defvar`

## Rationale

`defvar` preserves existing values on re-evaluation, which is the standard Common Lisp behavior. This ensures:

- Configuration values are preserved even when files are reloaded
- Values set by application developers are not unintentionally reset
- Correct configuration is maintained during test execution

## Testing

- Confirmed all existing tests pass
- Verified database configuration is correctly preserved during `clails test` command execution

## Related Issue

Fixes #137
