### PR TITLE
Fix duplicate columns in initialize-table-information

### DIFF
--- a/src/model/impl/mysql.lisp
+++ b/src/model/impl/mysql.lisp
@@ -203,7 +203,7 @@
 (defmethod fetch-columns-and-types-impl ((database-type <database-type-mysql>) connection table)
   (declare (ignore database-type))
   ;; select column_name, column_type, data_type, character_maximum_length, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION from information_schema.columns where table_name = 'todo'
-  (let ((sql "select column_name, data_type from information_schema.columns where table_name = ? order by ordinal_position"))
+  (let ((sql "select column_name, data_type from information_schema.columns where table_schema = database() and table_name = ? order by ordinal_position"))
     (log.sql sql :table table)
     (let* ((query (dbi:prepare connection sql))
            (result (dbi:execute query (list table))))
@@ -227,7 +227,7 @@
 (defmethod fetch-columns-and-types-plist-impl ((database-type <database-type-mysql>) connection table)
   (declare (ignore database-type))
   ;; select column_name, column_type, data_type, character_maximum_length, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION from information_schema.columns where table_name = 'todo'
-  (let ((sql "select column_name, data_type from information_schema.columns where table_name = ? order by ordinal_position"))
+  (let ((sql "select column_name, data_type from information_schema.columns where table_schema = database() and table_name = ? order by ordinal_position"))
     (log.sql sql :table table)
     (let* ((query (dbi:prepare connection sql))
           (result (dbi:execute query (list table))))

--- a/src/model/impl/postgresql.lisp
+++ b/src/model/impl/postgresql.lisp
@@ -226,7 +226,7 @@
 
 (defmethod fetch-columns-and-types-impl ((database-type <database-type-postgresql>) connection table)
   (declare (ignore database-type))
-  (let ((sql "select COLUMN_NAME, DATA_TYPE from information_schema.columns where table_name = ? order by ordinal_position"))
+  (let ((sql "select COLUMN_NAME, DATA_TYPE from information_schema.columns where table_schema = current_schema() and table_name = ? order by ordinal_position"))
     (log.sql sql :table table)
     (let* ((query (dbi:prepare connection sql))
           (result (dbi:execute query (list table))))
@@ -249,7 +249,7 @@
 
 (defmethod fetch-columns-and-types-plist-impl ((database-type <database-type-postgresql>) connection table)
   (declare (ignore database-type))
-  (let ((sql "select COLUMN_NAME, DATA_TYPE from information_schema.columns where table_name = ? order by ordinal_position"))
+  (let ((sql "select COLUMN_NAME, DATA_TYPE from information_schema.columns where table_schema = current_schema() and table_name = ? order by ordinal_position"))
     (log.sql sql :table table)
     (let* ((query (dbi:prepare connection sql))
           (result (dbi:execute query (list table))))


### PR DESCRIPTION
## Summary

Fixed the issue where `initialize-table-information` function retrieves duplicate column information when fetching table metadata.

## Problem

When querying `information_schema.columns` with only `table_name` condition, it searches for tables with the same name across all databases (development, te
st, etc.) on the same MySQL instance, resulting in duplicate column information.

### Observed Symptoms

- 27 rows of column information returned for a table with 11 columns
- Each column appears twice (retrieved from both dev and test databases)
- Unrelated columns from `performance_schema` are also included

## Changes

### MySQL (`src/model/impl/mysql.lisp`)

Added `table_schema = database()` condition to SQL queries in `fetch-columns-and-types-impl` and `fetch-columns-and-types-plist-impl` methods.

**Before:**
```sql
select column_name, data_type from information_schema.columns
where table_name = ?
order by ordinal_position
```

**After:**
```sql
select column_name, data_type from information_schema.columns
where table_schema = database() and table_name = ?
order by ordinal_position
```

### PostgreSQL (`src/model/impl/postgresql.lisp`)

Added `table_schema = current_schema()` condition to SQL queries in `fetch-columns-and-types-impl` and `fetch-columns-and-types-plist-impl` methods.

**Before:**
```sql
select COLUMN_NAME, DATA_TYPE from information_schema.columns
where table_name = ?
order by ordinal_position
```

**After:**
```sql
select COLUMN_NAME, DATA_TYPE from information_schema.columns
where table_schema = current_schema() and table_name = ?
order by ordinal_position
```

## Impact Scope

- Model initialization process for all MySQL-based models
- Model initialization process for all PostgreSQL-based models

## Testing

- Confirmed existing tests pass
- Verified column information is not duplicated in environments with multiple databases

## Related Issue

fix #139 
