### PR TITLE
Fix incorrect argument order for log-level-enabled-p in src/model

### DIFF
--- a/src/model/bulk.lisp
+++ b/src/model/bulk.lisp
@@ -270,7 +270,7 @@
    @param batch-size [integer] Batch size
    @param callback [function] Function to process each batch
    "
-  (when (log-level-enabled-p :sql :debug)
+  (when (log-level-enabled-p :debug :sql)
     (log.sql (format nil "PostgreSQL CURSOR: ~A" sql))
     (log.sql (format nil "PARAMS: ~A" params)))
 
@@ -339,7 +339,7 @@
    @param batch-size [integer] Batch size
    @param callback [function] Function to process each batch
    "
-  (when (log-level-enabled-p :sql :debug)
+  (when (log-level-enabled-p :debug :sql)
     (log.sql (format nil "MySQL STREAMING: ~A" sql))
     (log.sql (format nil "PARAMS: ~A" params)))
 
@@ -382,7 +382,7 @@
    @param batch-size [integer] Batch size
    @param callback [function] Function to process each batch
    "
-  (when (log-level-enabled-p :sql :debug)
+  (when (log-level-enabled-p :debug :sql)
     (log.sql (format nil "SQLite3 LIMIT/OFFSET: ~A" sql))
     (log.sql (format nil "PARAMS: ~A" params)))
 
@@ -658,7 +658,7 @@
                                    (extract-plist-values plist columns model-class))
                                  batch))))
 
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql (format nil "sql: ~S" sql))
       (log.sql (format nil "params: ~S" params)))
 
@@ -694,7 +694,7 @@
                                    (extract-instance-values inst columns model-class))
                                  batch))))
 
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql (format nil "sql: ~S" sql))
       (log.sql (format nil "params: ~S" params)))
 
@@ -970,7 +970,7 @@
                                   table-name set-clause))
                       (conn (or connection (get-connection))))
 
-                 (when (log-level-enabled-p :sql :debug)
+                 (when (log-level-enabled-p :debug :sql)
                    (log.sql (format nil "sql: ~S" sql)))
 
                  ;; Execute for each instance
@@ -983,7 +983,7 @@
                    (let ((params (append
                                   (extract-instance-values instance columns model-class)
                                   (list (ref instance :id)))))
-                     (when (log-level-enabled-p :sql :debug)
+                     (when (log-level-enabled-p :debug :sql)
                        (log.sql (format nil "params: ~S" params)))
                      (dbi-cp:execute (dbi-cp:prepare conn sql) params)
                      (incf total)))
@@ -1110,7 +1110,7 @@
                                   placeholders))
                       (conn (or connection (get-connection))))
 
-                 (when (log-level-enabled-p :sql :debug)
+                 (when (log-level-enabled-p :debug :sql)
                    (log.sql (format nil "sql: ~S" sql))
                    (log.sql (format nil "params: ~S" ids)))
 

--- a/src/model/impl/sqlite3-lock.lisp
+++ b/src/model/impl/sqlite3-lock.lisp
@@ -33,7 +33,7 @@
                       (:immediate "BEGIN IMMEDIATE")
                       (:exclusive "BEGIN EXCLUSIVE")
                       (otherwise "BEGIN TRANSACTION"))))
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql begin-sql))
     (sqlite:execute-non-query 
      (dbi.driver:connection-handle conn) 

--- a/src/model/lock.lisp
+++ b/src/model/lock.lisp
@@ -71,7 +71,7 @@
        ;; Set busy timeout for SQLite3
        (set-busy-timeout *database-type* ,connection-var)
 
-       (when (log-level-enabled-p :sql :debug)
+       (when (log-level-enabled-p :debug :sql)
          (log.sql (format nil "BEGIN LOCKED TRANSACTION (mode: ~A)" ,mode-var)))
 
        ;; Retry logic for SQLite3 lock errors
@@ -102,7 +102,7 @@
    @return [boolean] T if module was loaded, NIL if already loaded
    "
   (unless clails/environment:*sqlite3-lock-module-loaded*
-    (when (log-level-enabled-p :sql :info)
+    (when (log-level-enabled-p :info :sql)
       (log.sql "Loading SQLite3 lock module"))
     (load (merge-pathnames "src/model/impl/sqlite3-lock.lisp"
                            (asdf:system-source-directory :clails)))
@@ -165,7 +165,7 @@
               (progn
                 (incf retry-count)
                 (let ((wait-ms (* 100 (expt 2 (1- retry-count)))))
-                  (when (log-level-enabled-p :sql :warn)
+                  (when (log-level-enabled-p :warn :sql)
                     (log.sql (format nil "SQLite3 database locked, retry ~A/~A after ~Ams"
                                      retry-count max-retries wait-ms)))
                   (sleep (/ wait-ms 1000.0))))
@@ -223,7 +223,7 @@
    @return [null] Returns NIL
    "
   (let ((timeout-ms clails/environment:*sqlite3-busy-timeout*))
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql (format nil "PRAGMA busy_timeout = ~A" timeout-ms)))
     (dbi-cp:execute
      (dbi-cp:prepare connection (format nil "PRAGMA busy_timeout = ~A" timeout-ms))

--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -217,7 +217,7 @@
    "
   (multiple-value-bind (sql params)
       (generate-query query named-values :convert-types convert-types)
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql (format nil "sql: ~S" query))
       (log.sql (format nil "params: ~S" params)))
     (let* ((connection (get-connection))
@@ -330,7 +330,7 @@
         (let* ((table-name (kebab->snake (slot-value inst 'clails/model/base-model::table-name)))
                (sql (format NIL "DELETE FROM ~A WHERE id = ?" table-name))
                (params (list (ref inst :id))))
-          (when (log-level-enabled-p :sql :debug)
+          (when (log-level-enabled-p :debug :sql)
             (log.sql (format nil "sql: ~S" sql))
             (log.sql (format nil "params: ~S" params)))
           (let ((connection (get-connection)))
@@ -376,7 +376,7 @@
                       when (not (frozen-p i))
                         collect (ref i :id)))
                (sql (format NIL "DELETE FROM ~A WHERE id IN (~{?~*~^, ~})" table-name ids)))
-          (when (log-level-enabled-p :sql :debug)
+          (when (log-level-enabled-p :debug :sql)
             (log.sql (format nil "sql: ~S" sql))
             (log.sql (format nil "ids: ~S" ids)))
           (prog1
@@ -902,7 +902,7 @@
         (appendf final-params (list (getf named-values offset-param))))
       
       ;; For debug
-      (when (log-level-enabled-p :sql :debug)
+      (when (log-level-enabled-p :debug :sql)
         (log.sql (format nil "sql: ~S" final-sql))
         (log.sql (format nil "params: ~S" final-params)))
       
@@ -1556,7 +1556,7 @@
                                      (funcall (getf column-info :cl-db-fn) value)
                                      value)))
 
-      (when (log-level-enabled-p :sql :debug)
+      (when (log-level-enabled-p :debug :sql)
         (log.sql (format nil "sql: ~S" sql))
         (log.sql (format nil "params: ~S" params)))
 
@@ -1638,7 +1638,7 @@
     ;; append where-params
     (setf params (append params where-params))
 
-    (when (log-level-enabled-p :sql :debug)
+    (when (log-level-enabled-p :debug :sql)
       (log.sql (format nil "sql: ~S" sql))
       (log.sql (format nil "params: ~S" params)))
 
@@ -1870,7 +1870,7 @@
    @param param-values [list] Parameter values
    @return [list of plist] Query results (list of plists)
    "
-  (when (log-level-enabled-p :sql :debug)
+  (when (log-level-enabled-p :debug :sql)
     (log.sql (format nil "sql: ~A" sql-string))
     (log.sql (format nil "params: ~S" param-values)))
 
@@ -1887,7 +1887,7 @@
    @param param-values [list] Parameter values
    @return [integer] Number of affected rows
    "
-  (when (log-level-enabled-p :sql :debug)
+  (when (log-level-enabled-p :debug :sql)
     (log.sql (format nil "sql: ~A" sql-string))
     (log.sql (format nil "params: ~S" param-values)))
 

--- a/src/model/transaction.lisp
+++ b/src/model/transaction.lisp
@@ -40,10 +40,10 @@
          (save address))))
    "
   `(progn
-     (when (log-level-enabled-p :sql :debug)
+     (when (log-level-enabled-p :debug :sql)
        (log.sql "BEGIN TRANSACTION"))
      (dbi-cp:with-transaction ,connection
-       (when (log-level-enabled-p :sql :debug)
+       (when (log-level-enabled-p :debug :sql)
          (log.sql "EXECUTING TRANSACTION"))
        ,@body)))
 


### PR DESCRIPTION
Corrected the argument order of `log-level-enabled-p` calls throughout the src/model directory.
The correct order is `:level :logger` (e.g., `:debug :sql`), not `:logger :level`.
