### PR TITLE
Fix JOIN clause to apply kebab->snake conversion to table names

### DIFF
--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -998,7 +998,7 @@
                    (case (join-type join-obj)
                      (:inner-join "INNER JOIN")
                      (:left-join "LEFT JOIN"))
-                   target-table-name
+                   (kebab->snake target-table-name)
                    (kebab->snake target-alias)
                    on-clause))))))
 


### PR DESCRIPTION
Previously, JOIN clauses were not converting table names from kebab-case to snake_case, causing SQL errors when JOINs were used.