### PR TITLE
Improve test summary to show both passed and failed packages

### DIFF
--- a/src/test/runner.lisp
+++ b/src/test/runner.lisp
@@ -138,7 +138,8 @@
   (let ((*active-tags* tags)
         (*excluded-tags* excluded-tags)
         (*active-packages* packages)
-        (failed-package-tests nil))
+        (failed-package-tests nil)
+        (passed-package-tests nil))
     (if (or tags excluded-tags packages)
         (let ((filtered-tests (get-filtered-tests)))
           (if filtered-tests
@@ -153,18 +154,24 @@
                                                        (get-tests-by-package pkg))))
                           (when pkg-tests
                             (format t "~%;; testing '~A'~%" pkg)
-                            ;; Record failed test names
+                            ;; Record test results
                             (let ((result (run-tests-with-setup-teardown pkg pkg-tests style)))
-                              (unless result
-                                (setf all-passed nil)
-                                ;; Simply record that this package had failures
-                                (push (cons pkg pkg-tests) failed-package-tests))))))
-                      ;; Print summary of failed tests
+                              (if result
+                                  (push pkg passed-package-tests)
+                                  (progn
+                                    (setf all-passed nil)
+                                    (push (cons pkg pkg-tests) failed-package-tests)))))))
+                      ;; Print summary of test results
+                      (format t "~%~%=== Test Results Summary ===~%")
+                      (when passed-package-tests
+                        (format t "~%Passed Packages (~D):~%" (length passed-package-tests))
+                        (dolist (pkg (reverse passed-package-tests))
+                          (format t "  ~A~%" pkg)))
                       (when failed-package-tests
-                        (format t "~%~%=== Failed Tests Summary ===~%")
+                        (format t "~%Failed Packages (~D):~%" (length failed-package-tests))
                         (dolist (entry (reverse failed-package-tests))
                           (let ((pkg (car entry)))
-                            (format t "~%Package: ~A~%" pkg))))
+                            (format t "  ~A~%" pkg))))
                       all-passed)
                     ;; When filtering by tags only, run all at once
                     (let ((all-passed t))
@@ -180,16 +187,23 @@
                                    (when tests
                                      (format t "~%;; testing '~A'~%" pkg)
                                      (let ((result (run-tests-with-setup-teardown pkg (nreverse tests) style)))
-                                       (unless result
-                                         (setf all-passed nil)
-                                         (push (cons pkg tests) failed-package-tests)))))
+                                       (if result
+                                           (push pkg passed-package-tests)
+                                           (progn
+                                             (setf all-passed nil)
+                                             (push (cons pkg tests) failed-package-tests))))))
                                  pkg-test-map))
-                      ;; Print summary of failed tests
+                      ;; Print summary of test results
+                      (format t "~%~%=== Test Results Summary ===~%")
+                      (when passed-package-tests
+                        (format t "~%Passed Packages (~D):~%" (length passed-package-tests))
+                        (dolist (pkg (reverse passed-package-tests))
+                          (format t "  ~A~%" pkg)))
                       (when failed-package-tests
-                        (format t "~%~%=== Failed Tests Summary ===~%")
+                        (format t "~%Failed Packages (~D):~%" (length failed-package-tests))
                         (dolist (entry (reverse failed-package-tests))
                           (let ((pkg (car entry)))
-                            (format t "~%Package: ~A~%" pkg))))
+                            (format t "  ~A~%" pkg))))
                       all-passed)))
               (progn
                 (format t "~&No tests matched the filter criteria.~%")
@@ -205,18 +219,24 @@
                     (let ((pkg-tests (get-tests-by-package pkg)))
                       (when pkg-tests
                         (format t "~%;; testing '~A'~%" pkg)
-                        ;; Record failed test names
+                        ;; Record test results
                         (let ((result (run-tests-with-setup-teardown pkg pkg-tests style)))
-                          (unless result
-                            (setf all-passed nil)
-                            ;; Simply record that this package had failures
-                            (push (cons pkg pkg-tests) failed-package-tests))))))
-                  ;; Print summary of failed tests
+                          (if result
+                              (push pkg passed-package-tests)
+                              (progn
+                                (setf all-passed nil)
+                                (push (cons pkg pkg-tests) failed-package-tests)))))))
+                  ;; Print summary of test results
+                  (format t "~%~%=== Test Results Summary ===~%")
+                  (when passed-package-tests
+                    (format t "~%Passed Packages (~D):~%" (length passed-package-tests))
+                    (dolist (pkg (reverse passed-package-tests))
+                      (format t "  ~A~%" pkg)))
                   (when failed-package-tests
-                    (format t "~%~%=== Failed Tests Summary ===~%")
+                    (format t "~%Failed Packages (~D):~%" (length failed-package-tests))
                     (dolist (entry (reverse failed-package-tests))
                       (let ((pkg (car entry)))
-                        (format t "~%Package: ~A~%" pkg))))
+                        (format t "  ~A~%" pkg))))
                   all-passed)
                 (progn
                   (format t "~&No tests found.~%")


### PR DESCRIPTION
## Summary
Improved the test runner summary to display both passed and failed packages separately. This makes it clear which tests were executed even when all tests pass successfully.

## Background
Previously, only failed packages were displayed in the summary. When all tests passed, there was no indication of which packages were actually tested without reviewing the full log output.

## Changes
- Added `passed-package-tests` variable to track successful packages
- Changed test result evaluation from `unless` to `if` to record both success and failure
- Split summary display into two sections: "Passed Packages" and "Failed Packages"
- Display package count for each section along with the list of packages

## Test Results

### Before
When all tests passed, no summary section was displayed at all, making it unclear which packages were actually tested.

When there were failures:
```
=== Failed Tests Summary ===

Package: PACKAGE-C
```

### After
```
=== Test Results Summary ===

Passed Packages (3):
  TODOAPP-TEST/SAMPLE
  TODOAPP-TEST/MODELS/TODO
  TODOAPP-TEST/CONTROLLERS/TODO-CONTROLLER
```

When there are failed packages:
```
=== Test Results Summary ===

Passed Packages (2):
  PACKAGE-A
  PACKAGE-B

Failed Packages (1):
  PACKAGE-C
```

## Verification
Verified with E2E tests:
```bash
make e2e.test
```

Confirmed that all tests pass and executed packages are clearly displayed in the summary.