### PR TITLE
Add Dockerfile.cli for running clails CLI without local Roswell/SBCL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+tmp
+.dev_image_build
+.test_image_built
+.e2e_image_build
+clails-design-review.md
+clails-issue.md

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,36 @@
+FROM fukamachi/sbcl:2.5.10
+
+RUN apt-get update && apt-get install -y \
+  default-libmysqlclient-dev \
+  libpq-dev \
+  libsqlite3-dev \
+  default-mysql-client \
+  postgresql-client \
+  sqlite3 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 clails && useradd -m -u 1000 -g clails -s /bin/bash clails
+
+USER clails
+WORKDIR /home/clails
+
+RUN ros run -e "(ql-dist:install-dist \"http://dist.shirakumo.org/shirakumo.txt\" :prompt nil)"
+RUN ros install rove
+RUN ros install fukamachi/cl-dbi
+RUN ros install tamurashingo/cl-dbi-connection-pool
+RUN ros install tamurashingo/cl-batis
+RUN ros install tamurashingo/getcmd
+
+ENV PATH="/home/clails/.roswell/bin:${PATH}"
+
+COPY --chown=clails:clails . /home/clails/app
+ENV CL_SOURCE_REGISTRY="/home/clails/app"
+
+RUN ros install /home/clails/app/roswell/clails.ros
+RUN clails --help
+
+EXPOSE 5000
+
+WORKDIR /workspace
+ENTRYPOINT ["clails"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,11 @@ e2e.console:
 	@echo "Starting E2E test console..."
 	docker compose -f docker-compose.e2e.yml run --rm e2e-test bash
 
+
+# ----------------------------------------
+# clails CLI image (docker run tamurashingo/clails ...)
+# ----------------------------------------
+.PHONY: cli.build
+cli.build:
+	docker build -f Dockerfile.cli -t tamurashingo/clails .
+

--- a/README.md
+++ b/README.md
@@ -63,6 +63,42 @@ ros install tamurashingo/clails/v0.0.2
 clails --help
 ```
 
+### Using clails via Docker (no local Roswell/SBCL required)
+
+If you don't want to install Roswell/SBCL locally, you can build and run `clails`
+as a Docker image instead. Every subcommand operates on the host's current
+directory, so bind-mount it with `-v "$PWD":/workspace`:
+
+```bash
+docker build -f Dockerfile.cli -t tamurashingo/clails .
+# (once published to Docker Hub, `docker pull tamurashingo/clails` will replace the build step)
+
+docker run --rm -it -v "$PWD":/workspace tamurashingo/clails new myapp
+docker run --rm -it -v "$PWD":/workspace tamurashingo/clails new myapp --database mysql
+```
+
+`generate:*`, `db:*`, `task`, `environment`, `test` and `server` work the same way,
+but must be run **from inside the project directory** on the host (not its parent),
+since they resolve the project from the current directory just like `new` does:
+
+```bash
+cd myapp
+docker run --rm -it -v "$PWD":/workspace tamurashingo/clails generate:model todo
+docker run --rm -it -v "$PWD":/workspace tamurashingo/clails db:migrate
+
+# server needs its port published and bound to 0.0.0.0 to be reachable from the host
+docker run --rm -it -v "$PWD":/workspace -p 5000:5000 tamurashingo/clails server --bind 0.0.0.0
+```
+
+The container runs as a fixed non-root user (uid/gid `1000`), so files created
+under the bind mount are owned by that uid rather than root. If your host user's
+uid isn't `1000`, pass `--user "$(id -u):$(id -g)"` to match your own account.
+
+Note: `clails stop` only works when called in the same process as a running
+`server` (e.g. via a connected swank REPL). Since each `docker run` starts a new
+process, use Ctrl-C or `docker stop` to stop a containerized `server` instead —
+both deliver SIGINT/SIGTERM, which `clails server` already handles gracefully.
+
 ## Quick Start
 
 ### Create a New Project


### PR DESCRIPTION
## Summary
- Add `Dockerfile.cli`, a standalone image that lets `clails new`, `generate:*`, `db:*`, `server`, etc. be run via `docker run -v "$PWD":/workspace tamurashingo/clails ...` without installing Roswell/SBCL locally
- Runs as a fixed non-root uid/gid (1000) so files written into the bind-mounted host directory aren't root-owned
- Add `make cli.build` and document the Docker usage flow (including the UID caveat and the `server`/`stop` interaction) in `README.md`
- Add `.dockerignore` so `COPY .` in `Dockerfile.cli` (and the existing `Dockerfile`/`Dockerfile.e2e`) doesn't pull in `.git`, build markers, or stray local files

## Test plan
- [x] `docker build -f Dockerfile.cli -t tamurashingo/clails .`
- [x] `docker run -v "$PWD":/workspace tamurashingo/clails new demoapp` creates the project on the host, owned by the host user (uid 1000)
- [x] Same with `--database mysql`, confirming `app/config/database.lisp` renders from the mysql template
- [x] `docker run -v "$PWD":/workspace tamurashingo/clails generate:model todo` (run from inside the project dir) generates the model/migration files
- [x] `docker run -p 5000:5000 -v "$PWD":/workspace tamurashingo/clails server --bind 0.0.0.0` starts the app and responds 200 to `curl`