### PR TITLE
Select clack server backend from the project's :depends-on

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -72,7 +72,8 @@
                #:clails-test/model/todo-tag-junction-query
                #:clails-test/task/registry
                #:clails-test/task/runner
-               #:clails-test/task/core)
+               #:clails-test/task/core
+               #:clails-test/cmd)
   :perform (test-op (o c)
              (uiop:symbol-call :rove :run c)))
 

--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -249,6 +249,36 @@
    "
   (error "Not yet implemented"))
 
+(defparameter +clack-handler-prefix+ "clack-handler-"
+  "Prefix shared by every Clack handler backend's ASDF system name.")
+
+(defun detect-server-backend (project-name)
+  "Detect the Clack server backend from the project's ASDF :depends-on.
+
+   Scans <project-name>'s :depends-on in declaration order and returns the
+   keyword for the first dependency named \"clack-handler-<name>\" (e.g.
+   \"clack-handler-woo\" -> :woo). When more than one clack-handler-* entry
+   is present, the one declared earliest wins. Returns nil when none is
+   found, leaving clack:clackup's own default (:hunchentoot) in effect.
+
+   @param project-name [string] Project name
+   @return [keyword|nil] Clack :server backend keyword, or nil if undetected
+   "
+  (handler-case
+      (let* ((system (asdf:find-system project-name))
+             (deps (asdf/component:component-sideway-dependencies system)))
+        (loop for dep in deps
+              when (and (stringp dep)
+                        (>= (length dep) (length +clack-handler-prefix+))
+                        (string= dep +clack-handler-prefix+
+                                 :end1 (length +clack-handler-prefix+)))
+                return (intern (string-upcase
+                                (subseq dep (length +clack-handler-prefix+)))
+                               :keyword)))
+    (error (e)
+      (warn "Failed to detect clack server backend for project ~a: ~a" project-name e)
+      nil)))
+
 (defun server (&key (port "5000") (bind "127.0.0.1") swank-port (swank-address "127.0.0.1"))
   "Start the web server with the specified port and bind address.
 
@@ -269,12 +299,14 @@
          (builder `(lack:builder ,@args)))
     (setf *app* (eval builder)))
 
-  (setf *handler*
-        (clack:clackup *app*
-                       :debug nil
-                       :use-thread T
-                       :port (parse-integer port)
-                       :address bind))
+  (let ((backend (detect-server-backend *project-name*)))
+    (setf *handler*
+          (apply #'clack:clackup *app*
+                 :debug nil
+                 :use-thread T
+                 :port (parse-integer port)
+                 :address bind
+                 (when backend (list :server backend)))))
 
   (call-startup-hooks)
   (clack::with-handle-interrupt

--- a/template/project/base.asd.tmpl
+++ b/template/project/base.asd.tmpl
@@ -13,6 +13,13 @@
   :pathname "app"
   :depends-on ("clails"
                "swank"
+               ;; application server
+               ;; clails uses clack, which does not bundle a server backend by default.
+               ;; choose one of the following (see https://github.com/fukamachi/clack):
+               "clack-handler-hunchentoot"
+               ;; "clack-handler-wookie"
+               ;; "clack-handler-toot"
+               ;; "clack-handler-woo"
                "<%= (@ project-name ) %>/application-loader")
   :in-order-to ((test-op (test-op "<%= (@ project-name ) %>-test"))))
 

--- a/template/project/clails.boot.tmpl
+++ b/template/project/clails.boot.tmpl
@@ -6,7 +6,7 @@
                         (uiop:ensure-directory-pathname clails-home)
                         (uiop/os:getcwd))))
   (push project-dir asdf:*central-registry*)
-  (asdf:load-system :<%= (@ project-name ) %>)
+  (ql:quickload :<%= (@ project-name ) %>)
   (setf clails/environment:*project-dir* project-dir)
   (setf clails/environment:*migration-base-dir* clails/environment:*project-dir*)
   (setf clails/environment:*task-base-dir* clails/environment:*project-dir*))

--- a/test/cmd.lisp
+++ b/test/cmd.lisp
@@ -1,0 +1,27 @@
+;;;; Test for detect-server-backend (src/cmd.lisp)
+
+(defpackage #:clails-test/cmd
+  (:use #:cl
+        #:rove))
+
+(in-package #:clails-test/cmd)
+
+(deftest test-detect-server-backend
+  (testing "uses the sole declared clack-handler-* dependency"
+    (asdf:defsystem "clails-test-fake-app-single"
+      :depends-on ("clails" "clack-handler-woo"))
+    (ok (eq (clails/cmd::detect-server-backend "clails-test-fake-app-single") :woo)))
+
+  (testing "prefers whichever clack-handler-* is declared first"
+    (asdf:defsystem "clails-test-fake-app-order-a"
+      :depends-on ("clails" "clack-handler-woo" "clack-handler-hunchentoot"))
+    (ok (eq (clails/cmd::detect-server-backend "clails-test-fake-app-order-a") :woo))
+
+    (asdf:defsystem "clails-test-fake-app-order-b"
+      :depends-on ("clails" "clack-handler-hunchentoot" "clack-handler-woo"))
+    (ok (eq (clails/cmd::detect-server-backend "clails-test-fake-app-order-b") :hunchentoot)))
+
+  (testing "returns nil when no clack-handler-* dependency is declared"
+    (asdf:defsystem "clails-test-fake-app-none"
+      :depends-on ("clails" "swank"))
+    (ok (null (clails/cmd::detect-server-backend "clails-test-fake-app-none")))))


### PR DESCRIPTION
## Summary
- Fix `server` always using Hunchentoot: `clack:clackup` was called with no `:server` keyword, so Clack's hard-coded default (`:hunchentoot`) was used even when the generated app declared a different `clack-handler-*` dependency
- `cmd.lisp` gains `detect-server-backend`, which reads the project's `.asd` `:depends-on` in declaration order and passes the first `clack-handler-*` match to `clackup` as `:server` — switching backends now only requires editing the app's `.asd` (no `clails.boot` changes needed)
- `clails.boot.tmpl` now uses `ql:quickload` instead of `asdf:load-system`, so a declared `clack-handler-*` dependency (or any other missing dependency) is fetched from Quicklisp automatically on a fresh install
- `base.asd.tmpl` depends on `clack-handler-hunchentoot` by default, with `clack-handler-wookie` / `clack-handler-toot` / `clack-handler-woo` left as commented-out alternatives (fixed the Woo system name to `clack-handler-woo`, matching fukamachi/woo's actual ASDF system)
- Add `test/cmd.lisp` unit tests for `detect-server-backend` (single dependency, declaration-order priority between two handlers, and the no-match fallback)

## Test plan
- [x] `make test` — full `clails-test` suite passes, including the new `clails-test/cmd` tests
- [x] Rebuilt `tamurashingo/clails` Docker image, created a project under `./tmp/test-project` via `clails new`, confirmed the generated `.asd` depends on `clack-handler-hunchentoot`
- [x] Started the server in that project; log shows `Hunchentoot server is started.` and `curl` returns `HTTP 200` (no regression from the `nil`/single-dependency fallback path)
- [x] Verified `detect-server-backend`'s ordering logic directly (`ros run` against ad hoc `asdf:defsystem` fixtures): single `clack-handler-woo` dependency selects `:woo`; `clack-handler-woo` declared before `clack-handler-hunchentoot` selects `:woo`, and the reverse order selects `:hunchentoot`; no `clack-handler-*` dependency returns `nil` (falls back to Clack's own `:hunchentoot` default)