### PR TITLE
Register models via app/models/package.lisp, warn on unregistered ones

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -73,6 +73,7 @@
                #:clails-test/task/registry
                #:clails-test/task/runner
                #:clails-test/task/core
+               #:clails-test/project/generate
                #:clails-test/cmd)
   :perform (test-op (o c)
              (uiop:symbol-call :rove :run c)))

--- a/document/model.md
+++ b/document/model.md
@@ -172,6 +172,24 @@ Execute once at application startup.
 (clails/model/base-model:initialize-table-information)
 ```
 
+### Model File Loading and app/models/package.lisp
+
+clails uses ASDF's package-inferred-system, so only files reachable via the `:import-from`
+dependency graph starting from `app/application-loader.lisp`'s `defpackage` get loaded
+automatically. Running `clails generate:model` (including via `generate:scaffold`) appends the
+new model's package to `app/models/package.lisp`'s `defpackage` as an `:import-from` entry, and
+`app/application-loader.lisp` imports `app/models/package.lisp` once so every generated model
+gets pulled in together.
+
+If a model file is added to `app/models/` by hand and never gets registered this way, its
+package/symbols will never be loaded, and `db:migrate` / `db:seed` will fail with a
+package/symbol-not-found error. Before running, `clails db:migrate` and `clails db:seed` scan
+every file under `app/models/` and print a warning for any model whose package isn't loaded
+(`clails/project/generate:check-unregistered-models`). If you see this warning, add the
+`:import-from` entry to `app/models/package.lisp` by hand — don't re-run
+`clails generate:model <name>` to fix it, since the model file already exists and would just be
+overwritten (`generate:model` has no safe "register an existing file" mode).
+
 ---
 
 ## 3. Defining Models with Parent-Child Relationships

--- a/document/model_ja.md
+++ b/document/model_ja.md
@@ -172,6 +172,24 @@ YYYYmmdd-HHMMSS-description.lisp
 (clails/model/base-model:initialize-table-information)
 ```
 
+### モデルファイルの読み込みと app/models/package.lisp
+
+`clails` は ASDF の package-inferred-system を採用しており、`app/application-loader.lisp` の
+`defpackage` から辿れる `:import-from` の依存グラフに載っているファイルだけが自動的にロードされます。
+`clails generate:model`（`generate:scaffold` 経由も含む）でモデルを生成すると、そのモデルのパッケージが
+自動的に `app/models/package.lisp` の `defpackage` に `:import-from` として追記され、
+`app/application-loader.lisp` はこの `app/models/package.lisp` を一度だけ `:import-from` することで、
+生成済みの全モデルをまとめて読み込みます。
+
+手書きで `app/models/` にモデルファイルを追加した場合など、この登録から漏れているモデルがあると、
+そのモデルのパッケージ／シンボルはロードされず、`db:migrate` や `db:seed` の実行時に
+`package/symbol not found` のようなエラーになります。`clails db:migrate` / `clails db:seed` は
+実行前に `app/models/` 配下の全ファイルを走査し、対応するパッケージがロードされていないモデルがあれば
+警告を出力します（`clails/project/generate:check-unregistered-models`）。警告が出た場合は
+`app/models/package.lisp` に手動で `:import-from` を追記してください。この時点でモデルファイル自体は
+既に存在しているため、`clails generate:model <name>` を実行して解決しようとしないでください
+（`generate:model` には「既存ファイルを登録だけする」安全なモードはなく、単に上書きされてしまいます）。
+
 ---
 
 ## 3. 親子関係のある Model の定義

--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -12,7 +12,8 @@
                 #:gen/view
                 #:gen/controller
                 #:gen/scaffold
-                #:gen/task)
+                #:gen/task
+                #:check-unregistered-models)
   (:import-from #:clails/model/migration
                 #:db-create
                 #:db-migrate
@@ -186,6 +187,7 @@
    @param version [string] Migration name to migrate up to (optional). If nil, runs all pending migrations.
    @return [t] Migration execution result
    "
+  (check-unregistered-models)
   (db-migrate :version version))
 
 (defun db/status ()
@@ -233,6 +235,7 @@
 
    @return [t] Seeding execution result
    "
+  (check-unregistered-models)
   (startup-connection-pool)
   (initialize-table-information)
   (unwind-protect

--- a/src/model/migration.lisp
+++ b/src/model/migration.lisp
@@ -433,7 +433,11 @@
   "Seed the database with initial data from db/seeds.lisp.
 
    Implementation of db/seed command.
-   Loads all model files before executing seeds to ensure models are available.
+   Models are not loaded here; they must already be loaded via the application
+   loader (app/models/package.lisp, wired in by 'clails generate:model' or
+   'generate:scaffold') by the time this runs. See
+   clails/project/generate:check-unregistered-models for a warning when a model
+   file exists but was never registered.
    "
   (let ((seeds-file (format nil "~A/db/seeds.lisp" *migration-base-dir*)))
     (when (probe-file seeds-file)

--- a/src/project/generate.lisp
+++ b/src/project/generate.lisp
@@ -10,7 +10,8 @@
            #:gen/controller
            #:gen/scaffold
            #:gen/schema
-           #:gen/task))
+           #:gen/task
+           #:check-unregistered-models))
 (in-package #:clails/project/generate)
 
 
@@ -67,11 +68,11 @@
                                   :current-datetime ,(current-datetime)))))))
 
 (defun add-import-model (name)
-  "Add model import-from to application-loader.lisp.
+  "Add model import-from to app/models/package.lisp.
 
    @param name [string] Model name
    "
-  (let ((filepath (format nil "~A/app/application-loader.lisp" *project-dir*))
+  (let ((filepath (format nil "~A/app/models/package.lisp" *project-dir*))
         (package-name (format nil "~A/models/~A" *project-name* name)))
     (add-import-to-defpackage filepath package-name)))
 
@@ -122,7 +123,7 @@
                          (options (cddr form))
                          (new-options (copy-list options))
                          (import-found nil)
-                         (pkg-symbol (intern (string-upcase package-name) :keyword)))
+                         (pkg-symbol (make-symbol (string-upcase package-name))))
                     ;; Look for existing :import-from with the same package
                     (dolist (opt new-options)
                       (when (and (consp opt)
@@ -176,10 +177,37 @@
     (gen/template model-name filename "/app/models/" "template/generate/model.lisp.tmpl" overwrite))
   (let ((test-filename (format nil "~A.lisp" model-name)))
     (gen/template model-name test-filename "/test/models/" "template/generate/test/model.lisp.tmpl" overwrite))
-  ;; Add to application-loader.lisp
+  ;; Add to app/models/package.lisp
   (add-import-model model-name)
   ;; Add to test-loader.lisp
   (add-test-import-model model-name))
+
+(defun check-unregistered-models ()
+  "Warn about model files under app/models/ that are not part of any loaded package.
+
+   Intended as a safety net for models that were hand-written (or otherwise never
+   went through 'clails generate:model'/'generate:scaffold') and so never got an
+   :import-from entry anywhere in the application-loader.lisp dependency closure.
+   By the time this runs (from db:migrate/db:seed, after the project has been
+   loaded), any properly registered model's package already exists, so a missing
+   package is a reliable signal that the file was never wired up.
+
+   @return [null]
+   "
+  (let ((models-dir (format nil "~A/app/models/" *project-dir*)))
+    (when (probe-file models-dir)
+      (dolist (file (directory (format nil "~A*.lisp" models-dir)))
+        (let ((base-name (pathname-name file)))
+          (unless (string-equal base-name "package")
+            (let* ((package-name (format nil "~A/models/~A" *project-name* base-name))
+                   (upcased-package-name (string-upcase package-name)))
+              (unless (find-package upcased-package-name)
+                (format t "WARNING: app/models/~A.lisp is not loaded (no package \"~A\" found).~%"
+                        base-name upcased-package-name)
+                (format t "         Add (:import-from #:~A) to app/models/package.lisp to register it.~%"
+                        package-name)
+                (format t "         (the file already exists, so re-running 'clails generate:model ~A' would overwrite it.)~%"
+                        base-name)))))))))
 
 (defun gen/migration (migration-name &key (overwrite T))
   "Generate a migration file with unique timestamp prefix.

--- a/src/project/project.lisp
+++ b/src/project/project.lisp
@@ -153,6 +153,13 @@
                                (read-template "app/controllers/application-controller.lisp.tmpl"))
 
 
+    ;; model package
+    (create-file-with-template "app/models/package.lisp"
+                               project-name
+                               project-dir
+                               database
+                               (read-template "app/models/package.lisp.tmpl"))
+
     ;; view package
     (create-file-with-template "app/views/package.lisp"
                                project-name

--- a/template/project/app/application-loader.lisp.tmpl
+++ b/template/project/app/application-loader.lisp.tmpl
@@ -5,6 +5,7 @@
   (:import-from #:<%= (@ project-name ) %>/config/environment)
   (:import-from #:<%= (@ project-name ) %>/config/logger)
   (:import-from #:<%= (@ project-name ) %>/config/database)
+  (:import-from #:<%= (@ project-name ) %>/models/package)
   (:import-from #:<%= (@ project-name ) %>/controllers/application-controller)
   (:import-from #:<%= (@ project-name ) %>/views/package))
 (in-package #:<%= (@ project-name ) %>/application-loader)

--- a/template/project/app/models/package.lisp.tmpl
+++ b/template/project/app/models/package.lisp.tmpl
@@ -1,0 +1,5 @@
+; -*- mode: lisp -*-
+(in-package #:cl-user)
+(defpackage #:<%= (@ project-name ) %>/models/package
+  (:use #:cl))
+(in-package #:<%= (@ project-name ) %>/models/package)

--- a/template/project/db/package.lisp.tmpl
+++ b/template/project/db/package.lisp.tmpl
@@ -3,6 +3,7 @@
 (defpackage #:<%= (@ project-name ) %>-db
   (:use #:cl
         #:clails/model)
+  (:import-from #:<%= (@ project-name ) %>/models/package)
   (:import-from #:clails/model/migration
                 #:defmigration
                 #:create-table

--- a/test/project/generate.lisp
+++ b/test/project/generate.lisp
@@ -1,0 +1,76 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/project/generate
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/project/generate
+                #:gen/model
+                #:check-unregistered-models))
+(in-package #:clails-test/project/generate)
+
+(defparameter *test-project-name* "testproj")
+
+(setup
+  (uiop:setup-temporary-directory)
+  (setf clails/environment:*project-dir* uiop:*temporary-directory*)
+  (setf clails/environment:*project-name* *test-project-name*)
+  (ensure-directories-exist (merge-pathnames "app/models/" uiop:*temporary-directory*))
+  (ensure-directories-exist (merge-pathnames "test/models/" uiop:*temporary-directory*))
+  (with-open-file (out (merge-pathnames "app/application-loader.lisp" uiop:*temporary-directory*)
+                       :direction :output :if-exists :supersede)
+    (format out "; -*- mode: lisp -*-~%(in-package #:cl-user)~%(defpackage #:~A/application-loader~%  (:use #:cl)~%  (:import-from #:~A/models/package))~%(in-package #:~A/application-loader)~%"
+            *test-project-name* *test-project-name* *test-project-name*))
+  (with-open-file (out (merge-pathnames "app/models/package.lisp" uiop:*temporary-directory*)
+                       :direction :output :if-exists :supersede)
+    (format out "; -*- mode: lisp -*-~%(in-package #:cl-user)~%(defpackage #:~A/models/package~%  (:use #:cl))~%(in-package #:~A/models/package)~%"
+            *test-project-name* *test-project-name*))
+  (with-open-file (out (merge-pathnames "test/test-loader.lisp" uiop:*temporary-directory*)
+                       :direction :output :if-exists :supersede)
+    (format out "; -*- mode: lisp -*-~%(in-package #:cl-user)~%(defpackage #:~A-test/test-loader~%  (:use #:cl))~%(in-package #:~A-test/test-loader)~%"
+            *test-project-name* *test-project-name*)))
+
+(teardown
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t))
+
+(defun read-project-file (relative-path)
+  (uiop:read-file-string (merge-pathnames relative-path uiop:*temporary-directory*)))
+
+
+;;; Test: gen/model registers into app/models/package.lisp, not application-loader.lisp
+
+(deftest gen-model-registers-in-models-package-test
+  (testing "gen/model adds the new model to app/models/package.lisp and leaves application-loader.lisp alone"
+    (let ((loader-before (read-project-file "app/application-loader.lisp")))
+      (gen/model "widget")
+      (let ((models-package (read-project-file "app/models/package.lisp"))
+            (loader-after (read-project-file "app/application-loader.lisp")))
+        (ok (search "testproj/models/widget" models-package)
+            "app/models/package.lisp should import the new model's package")
+        (ok (search "#:testproj/models/widget" models-package)
+            "the import should be printed with the #: uninterned-symbol reader syntax")
+        (ok (string= loader-before loader-after)
+            "app/application-loader.lisp should not be modified by gen/model")))))
+
+
+;;; Test: check-unregistered-models
+
+(deftest check-unregistered-models-warns-for-unloaded-file-test
+  (testing "check-unregistered-models warns about a model file whose package was never loaded"
+    (with-open-file (out (merge-pathnames "app/models/foo.lisp" uiop:*temporary-directory*)
+                         :direction :output :if-exists :supersede)
+      (format out "; a hand-written model file, never registered anywhere~%"))
+    (let ((output (with-output-to-string (*standard-output*)
+                    (check-unregistered-models))))
+      (ok (search "foo" output)
+          "warning output should mention the unregistered model file"))))
+
+(deftest check-unregistered-models-silent-for-loaded-file-test
+  (testing "check-unregistered-models stays silent about a model file whose package is already loaded"
+    (with-open-file (out (merge-pathnames "app/models/bar.lisp" uiop:*temporary-directory*)
+                         :direction :output :if-exists :supersede)
+      (format out "; simulate a model that was already loaded via application-loader.lisp~%"))
+    (unless (find-package "TESTPROJ/MODELS/BAR")
+      (make-package "TESTPROJ/MODELS/BAR" :use '(#:cl)))
+    (let ((output (with-output-to-string (*standard-output*)
+                    (check-unregistered-models))))
+      (ok (not (search "bar" output))
+          "no warning expected once the model's package is loaded"))))


### PR DESCRIPTION
Closes #153

## Summary
- A model file that never went through `clails generate:model`/`generate:scaffold` (e.g. hand-written) could silently fall outside the package-inferred-system dependency graph rooted at `app/application-loader.lisp` and never load, failing later with a package/symbol-not-found error from `db:migrate`/`db:seed`.
- Introduce `app/models/package.lisp` as a dedicated model-registration aggregator; `clails generate:model` now writes there instead of directly into `app/application-loader.lisp`, which now imports it once.
- Add `check-unregistered-models`, run before `db:migrate` and `db:seed`, which warns about any `app/models/*.lisp` file whose package never got loaded (with guidance to register it manually, since the file already existing means re-running `generate:model` would just overwrite it).
- Fix `add-import-to-defpackage` to print `:import-from` entries as `#:name` (uninterned symbol) instead of a stray keyword designator, matching the hand-written templates.
- Update `document/model.md` / `model_ja.md` with the new model-loading mechanism.

## Test plan
- [x] `make test` — all 66 unit tests pass, including new tests in `test/project/generate.lisp`
- [x] `make e2e.test` — full scaffold → migrate → seed → serve → app-test-suite flow passes
- [x] Manually verified in a scaffolded project that `generate:model` registers into `app/models/package.lisp` (not `application-loader.lisp`) and that a hand-added, unregistered model file triggers the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)