### PR TITLE
Stop making swank an unconditional dependency of generated projects

### DIFF
--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -87,7 +87,7 @@
   (unless *swank-server*
     (handler-case
         (let ((swank-port (parse-integer port)))
-          (asdf:load-system :swank)
+          (ql:quickload :swank :silent t)
           (let ((var (find-symbol "*LOOPBACK-INTERFACE*" :swank)))
             (when var (setf (symbol-value var) address)))
           (setf *swank-server*

--- a/template/project/base.asd.tmpl
+++ b/template/project/base.asd.tmpl
@@ -12,7 +12,6 @@
   :license ""
   :pathname "app"
   :depends-on ("clails"
-               "swank"
                ;; application server
                ;; clails uses clack, which does not bundle a server backend by default.
                ;; choose one of the following (see https://github.com/fukamachi/clack):


### PR DESCRIPTION
Closes #163

## Summary
- `template/project/base.asd.tmpl` had `"swank"` unconditionally in `:depends-on`, so every generated project loaded the remote-debugging (Swank) library regardless of whether `--swank` was ever passed to `clails server` — unnecessary attack surface / dependency footprint in production. Removed it.
- `src/cmd.lisp`'s `start-swank-server` already loads swank lazily only when `--swank` is used, so it doesn't need the dependency preloaded. Changed its `(asdf:load-system :swank)` to `(ql:quickload :swank :silent t)` so swank is reliably fetched via Quicklisp on first use even if not already installed (silenced to match the other quiet quickload calls in this codebase).

## Test plan
- [x] `make test` — all 66 unit tests pass
- [x] `make e2e.test` — full scaffold → migrate → seed → serve → app-test-suite flow passes
- [x] Manually verified in a scaffolded project: generated `.asd` no longer lists `"swank"`; `clails server` (no `--swank`) starts cleanly with no swank-related output; `clails server --swank` loads swank via `ql:quickload` and starts the swank server on port 4005

🤖 Generated with [Claude Code](https://claude.com/claude-code)