### PR TITLE
Make startup/shutdown hook execution order match registration order

### DIFF
--- a/clails-test.asd
+++ b/clails-test.asd
@@ -74,6 +74,7 @@
                #:clails-test/task/runner
                #:clails-test/task/core
                #:clails-test/project/generate
+               #:clails-test/environment
                #:clails-test/cmd)
   :perform (test-op (o c)
              (uiop:symbol-call :rove :run c)))

--- a/document/command.md
+++ b/document/command.md
@@ -1002,13 +1002,15 @@ You can execute arbitrary processes when starting or stopping the server.
 
 ```common-lisp
 ;; Define in config/environment.lisp or similar
-(setf clails/environment:*startup-hooks*
-      (list #'(lambda ()
-                (format t "Server starting...~%"))))
+;; add-startup-hook/add-shutdown-hook append to the list, so hooks run in the
+;; order they were registered
+(clails/environment:add-startup-hook
+  #'(lambda ()
+      (format t "Server starting...~%")))
 
-(setf clails/environment:*shutdown-hooks*
-      (list #'(lambda ()
-                (format t "Server stopping...~%"))))
+(clails/environment:add-shutdown-hook
+  #'(lambda ()
+      (format t "Server stopping...~%")))
 ```
 
 ### Development with Swank Server

--- a/document/command_ja.md
+++ b/document/command_ja.md
@@ -1002,13 +1002,14 @@ clails server -p 8080
 
 ```common-lisp
 ;; config/environment.lisp などで定義
-(setf clails/environment:*startup-hooks*
-      (list #'(lambda ()
-                (format t "Server starting...~%"))))
+;; add-startup-hook/add-shutdown-hook は末尾に追加するため、登録した順に実行される
+(clails/environment:add-startup-hook
+  #'(lambda ()
+      (format t "Server starting...~%")))
 
-(setf clails/environment:*shutdown-hooks*
-      (list #'(lambda ()
-                (format t "Server stopping...~%"))))
+(clails/environment:add-shutdown-hook
+  #'(lambda ()
+      (format t "Server stopping...~%")))
 ```
 
 ### Swankサーバーを使った開発

--- a/document/environment.md
+++ b/document/environment.md
@@ -498,44 +498,54 @@ Each route entry is a plist with the following properties:
 
 #### `*startup-hooks*`
 
-Functions to execute at application startup.
+Functions to execute at application startup, **in list order**. The
+framework's own default (`clails/model/connection:startup-connection-pool`)
+is already in this list, so any hook you register runs after it.
 
 ```lisp
 clails/environment:*startup-hooks*
-;; => (#<FUNCTION ...> #<FUNCTION ...>)
+;; => ("clails/model/connection:startup-connection-pool" #<FUNCTION ...> ...)
 ```
 
-**Type**: `list of functions`
+**Type**: `list of functions (or function-name strings)`
 
-**Usage**:
+**Usage**: Use `add-startup-hook` to register a hook. It appends to the list,
+so hooks run in the order they were registered — do not `push` onto
+`*startup-hooks*` directly, since `push` prepends and would run your hook
+*before* the framework's default (and before any hook registered earlier).
+
 ```lisp
-;; Add startup hook
-(setf clails/environment:*startup-hooks*
-      (list #'(lambda ()
-                (format t "Application starting...~%")
-                (initialize-cache)
-                (connect-external-services))))
+;; Add startup hooks (registration order = execution order)
+(clails/environment:add-startup-hook
+  #'(lambda ()
+      (format t "Application starting...~%")
+      (initialize-cache)
+      (connect-external-services)))
 ```
 
 #### `*shutdown-hooks*`
 
-Functions to execute at application shutdown.
+Functions to execute at application shutdown, **in list order**. The
+framework's own default (`clails/model/connection:shutdown-connection-pool`)
+is already in this list, so any hook you register runs after it.
 
 ```lisp
 clails/environment:*shutdown-hooks*
-;; => (#<FUNCTION ...> #<FUNCTION ...>)
+;; => ("clails/model/connection:shutdown-connection-pool" #<FUNCTION ...> ...)
 ```
 
-**Type**: `list of functions`
+**Type**: `list of functions (or function-name strings)`
 
-**Usage**:
+**Usage**: Use `add-shutdown-hook` to register a hook. Same append-only
+behavior as `add-startup-hook` above.
+
 ```lisp
-;; Add shutdown hook
-(setf clails/environment:*shutdown-hooks*
-      (list #'(lambda ()
-                (format t "Application shutting down...~%")
-                (cleanup-cache)
-                (disconnect-external-services))))
+;; Add shutdown hooks (registration order = execution order)
+(clails/environment:add-shutdown-hook
+  #'(lambda ()
+      (format t "Application shutting down...~%")
+      (cleanup-cache)
+      (disconnect-external-services)))
 ```
 
 ---
@@ -867,16 +877,14 @@ qlot exec rove myapp-test.asd
 (clails/environment:set-environment 
   (clails/util:env-or-default "APP_ENV" "DEVELOP"))
 
-;; Set startup hooks
-(setf clails/environment:*startup-hooks*
-  '("clails/model/connection:startup-connection-pool"
-    "myapp/initializer:initialize-table-information"
-    "myapp/initializer:setup-logger"))
+;; Add startup hooks (they run after the framework's own default,
+;; clails/model/connection:startup-connection-pool, in the order registered)
+(clails/environment:add-startup-hook "myapp/initializer:initialize-table-information")
+(clails/environment:add-startup-hook "myapp/initializer:setup-logger")
 
-;; Set shutdown hooks
-(setf clails/environment:*shutdown-hooks*
-  '("myapp/finalizer:cleanup-resources"
-    "clails/model/connection:shutdown-connection-pool"))
+;; Add shutdown hooks (they run after the framework's own default,
+;; clails/model/connection:shutdown-connection-pool, in the order registered)
+(clails/environment:add-shutdown-hook "myapp/finalizer:cleanup-resources")
 ```
 
 ### app/config/database.lisp

--- a/document/environment_ja.md
+++ b/document/environment_ja.md
@@ -554,76 +554,67 @@ URL パスと Controller の対応を定義するルーティングテーブル�
 
 #### `*startup-hooks*`
 
-アプリケーション起動時に実行される関数のリストです。
+アプリケーション起動時に、**リストの並び順どおりに**実行される関数のリストです。
+フレームワーク既定のフック(`clails/model/connection:startup-connection-pool`)が
+あらかじめ登録されているため、自分で登録したフックはその後に実行されます。
 
-**型**: list of strings or symbols
+**型**: list of strings or functions
 
 **デフォルト値**: `'("clails/model/connection:startup-connection-pool")`
 
 **設定場所**: `app/config/environment.lisp`
 
 **指定方法**:
-- 文字列: `"package-name:function-name"` の形式で指定
-- シンボル: 関数名のシンボルで指定
+- 文字列: `"package-name:function-name"` の形式で指定（循環参照を避けたい場合はこちら）
+- 関数オブジェクト: `#'function-name` や `(lambda () ...)` で指定
 
-循環参照が発生する場合は、文字列で指定してください。
+（注意: シンボル単体 `'function-name` は受け付けません。関数呼び出し時に
+`etypecase` で `string`/`function` 以外は型エラーになります。）
+
+`add-startup-hook` でフックを登録してください。この関数はリストの**末尾に追加**するため、
+登録した順番がそのまま実行順になります。`*startup-hooks*` に対して直接 `push` するのは
+避けてください。`push` は先頭に追加するため、登録したフックがフレームワーク既定のフック
+（や、より前に登録した他のフック）より先に実行されてしまいます。
 
 **設定例**:
 ```lisp
-;; 文字列で指定（推奨: 循環参照を避けるため）
-(setf clails/environment:*startup-hooks*
-  '("clails/model/connection:startup-connection-pool"
-    "myapp/initializer:setup-logger"
-    "myapp/initializer:load-cache"))
+;; 登録順 = 実行順
+(clails/environment:add-startup-hook "myapp/initializer:setup-logger")
+(clails/environment:add-startup-hook "myapp/initializer:load-cache")
 
-;; シンボルで指定（循環参照がない場合のみ）
-(setf clails/environment:*startup-hooks*
-  '(clails/model/connection:startup-connection-pool
-    myapp/initializer:setup-logger
-    myapp/initializer:load-cache))
-
-;; 混在も可能
-(setf clails/environment:*startup-hooks*
-  '("clails/model/connection:startup-connection-pool"
-    myapp/initializer:setup-logger
-    "myapp/initializer:load-cache"))
+;; 関数オブジェクトでも指定可能
+(clails/environment:add-startup-hook
+  #'(lambda ()
+      (format t "starting...~%")))
 ```
 
 #### `*shutdown-hooks*`
 
-アプリケーション終了時に実行される関数のリストです。
+アプリケーション終了時に、**リストの並び順どおりに**実行される関数のリストです。
+フレームワーク既定のフック(`clails/model/connection:shutdown-connection-pool`)が
+あらかじめ登録されているため、自分で登録したフックはその後に実行されます。
 
-**型**: list of strings or symbols
+**型**: list of strings or functions
 
 **デフォルト値**: `'("clails/model/connection:shutdown-connection-pool")`
 
 **設定場所**: `app/config/environment.lisp`
 
 **指定方法**:
-- 文字列: `"package-name:function-name"` の形式で指定
-- シンボル: 関数名のシンボルで指定
+- 文字列: `"package-name:function-name"` の形式で指定（循環参照を避けたい場合はこちら）
+- 関数オブジェクト: `#'function-name` や `(lambda () ...)` で指定
 
-循環参照が発生する場合は、文字列で指定してください。
+（注意: シンボル単体 `'function-name` は受け付けません。関数呼び出し時に
+`etypecase` で `string`/`function` 以外は型エラーになります。）
+
+`add-shutdown-hook` でフックを登録してください。挙動は `add-startup-hook` と同様、
+末尾追加(登録順=実行順)です。
 
 **設定例**:
 ```lisp
-;; 文字列で指定（推奨: 循環参照を避けるため）
-(setf clails/environment:*shutdown-hooks*
-  '("clails/model/connection:shutdown-connection-pool"
-    "myapp/finalizer:cleanup-cache"
-    "myapp/finalizer:save-statistics"))
-
-;; シンボルで指定（循環参照がない場合のみ）
-(setf clails/environment:*shutdown-hooks*
-  '(clails/model/connection:shutdown-connection-pool
-    myapp/finalizer:cleanup-cache
-    myapp/finalizer:save-statistics))
-
-;; 混在も可能
-(setf clails/environment:*shutdown-hooks*
-  '("clails/model/connection:shutdown-connection-pool"
-    myapp/finalizer:cleanup-cache
-    "myapp/finalizer:save-statistics"))
+;; 登録順 = 実行順
+(clails/environment:add-shutdown-hook "myapp/finalizer:cleanup-cache")
+(clails/environment:add-shutdown-hook "myapp/finalizer:save-statistics")
 ```
 
 ---
@@ -957,16 +948,14 @@ qlot exec rove myapp-test.asd
 (clails/environment:set-environment 
   (clails/util:env-or-default "APP_ENV" "DEVELOP"))
 
-;; スタートアップフックの設定
-(setf clails/environment:*startup-hooks*
-  '("clails/model/connection:startup-connection-pool"
-    "myapp/initializer:initialize-table-information"
-    "myapp/initializer:setup-logger"))
+;; スタートアップフックの追加（フレームワーク既定の
+;; clails/model/connection:startup-connection-pool の後、登録した順に実行される）
+(clails/environment:add-startup-hook "myapp/initializer:initialize-table-information")
+(clails/environment:add-startup-hook "myapp/initializer:setup-logger")
 
-;; シャットダウンフックの設定
-(setf clails/environment:*shutdown-hooks*
-  '("myapp/finalizer:cleanup-resources"
-    "clails/model/connection:shutdown-connection-pool"))
+;; シャットダウンフックの追加（フレームワーク既定の
+;; clails/model/connection:shutdown-connection-pool の後、登録した順に実行される）
+(clails/environment:add-shutdown-hook "myapp/finalizer:cleanup-resources")
 ```
 
 ### app/config/database.lisp

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -24,7 +24,9 @@
            #:<database-type-postgresql>
            #:<database-type-sqlite3>
            #:<database-type-dummy>
-           #:set-environment))
+           #:set-environment
+           #:add-startup-hook
+           #:add-shutdown-hook))
 (in-package #:clails/environment)
 
 (defclass <database-type> ()
@@ -144,10 +146,20 @@
    Set in app/config/environment.lisp.")
 
 (defvar *startup-hooks*
-  '("clails/model/connection:startup-connection-pool"))
+  '("clails/model/connection:startup-connection-pool")
+  "List of functions (or function-name strings) to run at application startup,
+   in list order. Use add-startup-hook to append to this list so registration
+   order matches execution order; do not push onto it directly, since push
+   prepends and would run the newly added hook before the framework's own
+   default hooks (and before any hook registered earlier).")
 
 (defvar *shutdown-hooks*
-  '("clails/model/connection:shutdown-connection-pool"))
+  '("clails/model/connection:shutdown-connection-pool")
+  "List of functions (or function-name strings) to run at application shutdown,
+   in list order. Use add-shutdown-hook to append to this list so registration
+   order matches execution order; do not push onto it directly, since push
+   prepends and would run the newly added hook before the framework's own
+   default hooks (and before any hook registered earlier).")
 
 (defvar *default-lock-mode* :for-update
   "Default lock mode for with-locked-transaction macro.
@@ -239,3 +251,29 @@
   (let ((env (string-upcase env-name)))
     (when (check-environment-name env)
       (setf *project-environment* (intern env :KEYWORD)))))
+
+(defun add-startup-hook (hook)
+  "Register a hook to run at application startup.
+
+   Appends to *startup-hooks*, so hooks run in the order they were
+   registered (after any hook already present, including the framework's
+   own default). Prefer this over pushing onto *startup-hooks* directly,
+   which would reverse the intended execution order.
+
+   @param hook [string or function] Function name (e.g. \"package:function-name\") or a function object
+   @return [list] The updated *startup-hooks* list
+   "
+  (setf *startup-hooks* (append *startup-hooks* (list hook))))
+
+(defun add-shutdown-hook (hook)
+  "Register a hook to run at application shutdown.
+
+   Appends to *shutdown-hooks*, so hooks run in the order they were
+   registered (after any hook already present, including the framework's
+   own default). Prefer this over pushing onto *shutdown-hooks* directly,
+   which would reverse the intended execution order.
+
+   @param hook [string or function] Function name (e.g. \"package:function-name\") or a function object
+   @return [list] The updated *shutdown-hooks* list
+   "
+  (setf *shutdown-hooks* (append *shutdown-hooks* (list hook))))

--- a/template/project/app/config/environment.lisp.tmpl
+++ b/template/project/app/config/environment.lisp.tmpl
@@ -4,7 +4,9 @@
   (:use #:cl)
   (:import-from #:clails/environment
                 #:*project-environment*
-                #:*routing-tables*))
+                #:*routing-tables*
+                #:add-startup-hook
+                #:add-shutdown-hook))
 
 (in-package #:<%= (@ project-name ) %>/config/environment)
 
@@ -19,9 +21,9 @@
      :controller "<%= (@ project-name )%>/controllers/application-controller:<application-controller>")))
 
 
-;; startup hooks
-(push "<%= (@ project-name) %>/config/logger:initialize-logger" clails/environment:*startup-hooks*)
-(push "clails/model/base-model:initialize-table-information" clails/environment:*startup-hooks*)
+;; startup hooks (run in registration order, after the framework's own default hooks)
+(add-startup-hook "<%= (@ project-name) %>/config/logger:initialize-logger")
+(add-startup-hook "clails/model/base-model:initialize-table-information")
 
-;; shutdown hooks
-(push "<%= (@ project-name) %>/config/logger:finalize-logger" clails/environment:*shutdown-hooks*)
+;; shutdown hooks (run in registration order, after the framework's own default hooks)
+(add-shutdown-hook "<%= (@ project-name) %>/config/logger:finalize-logger")

--- a/test/environment.lisp
+++ b/test/environment.lisp
@@ -1,0 +1,74 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/environment
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/environment
+                #:*startup-hooks*
+                #:*shutdown-hooks*
+                #:add-startup-hook
+                #:add-shutdown-hook))
+(in-package #:clails-test/environment)
+
+(defparameter *saved-startup-hooks* nil)
+(defparameter *saved-shutdown-hooks* nil)
+
+(setup
+  (setf *saved-startup-hooks* *startup-hooks*)
+  (setf *saved-shutdown-hooks* *shutdown-hooks*))
+
+(teardown
+  (setf *startup-hooks* *saved-startup-hooks*)
+  (setf *shutdown-hooks* *saved-shutdown-hooks*))
+
+
+;;; Test: add-startup-hook / add-shutdown-hook append in registration order
+
+(deftest add-startup-hook-appends-in-registration-order-test
+  (testing "add-startup-hook appends to *startup-hooks*, preserving registration order"
+    (setf *startup-hooks* nil)
+    (add-startup-hook "hook-a")
+    (add-startup-hook "hook-b")
+    (add-startup-hook "hook-c")
+    (ok (equal '("hook-a" "hook-b" "hook-c") *startup-hooks*)
+        "hooks should appear in the same order they were registered, not reversed")))
+
+(deftest add-shutdown-hook-appends-in-registration-order-test
+  (testing "add-shutdown-hook appends to *shutdown-hooks*, preserving registration order"
+    (setf *shutdown-hooks* nil)
+    (add-shutdown-hook "hook-x")
+    (add-shutdown-hook "hook-y")
+    (ok (equal '("hook-x" "hook-y") *shutdown-hooks*)
+        "hooks should appear in the same order they were registered, not reversed")))
+
+(deftest add-startup-hook-runs-after-existing-default-hook-test
+  (testing "a hook added via add-startup-hook runs after a hook already present"
+    (setf *startup-hooks* (list "clails/model/connection:startup-connection-pool"))
+    (add-startup-hook "project/config/logger:initialize-logger")
+    (ok (equal '("clails/model/connection:startup-connection-pool"
+                 "project/config/logger:initialize-logger")
+               *startup-hooks*)
+        "the framework's own default hook should stay first, with newly added hooks following it")))
+
+
+;;; Test: clails/cmd:call-startup-hooks / call-shutdown-hooks execute in list order
+
+(deftest call-startup-hooks-executes-in-registration-order-test
+  (testing "call-startup-hooks runs hooks in the order they were registered"
+    (setf *startup-hooks* nil)
+    (let ((order '()))
+      (add-startup-hook (lambda () (setf order (append order (list :first)))))
+      (add-startup-hook (lambda () (setf order (append order (list :second)))))
+      (add-startup-hook (lambda () (setf order (append order (list :third)))))
+      (clails/cmd::call-startup-hooks)
+      (ok (equal '(:first :second :third) order)
+          "hooks should run first-registered-first, matching add-startup-hook's registration order"))))
+
+(deftest call-shutdown-hooks-executes-in-registration-order-test
+  (testing "call-shutdown-hooks runs hooks in the order they were registered"
+    (setf *shutdown-hooks* nil)
+    (let ((order '()))
+      (add-shutdown-hook (lambda () (setf order (append order (list :first)))))
+      (add-shutdown-hook (lambda () (setf order (append order (list :second)))))
+      (clails/cmd::call-shutdown-hooks)
+      (ok (equal '(:first :second) order)
+          "hooks should run first-registered-first, matching add-shutdown-hook's registration order"))))


### PR DESCRIPTION
Closes #152

## Summary
- `*startup-hooks*`/`*shutdown-hooks*` (`src/environment.lisp`) are lists that `call-startup-hooks`/`call-shutdown-hooks` (`src/cmd.lisp`) run through in list order, but the project template registered project hooks with `push`, which prepends — so the effective execution order ended up reversed from the order hooks appeared in the source file.
- Add `add-startup-hook`/`add-shutdown-hook`, which append to the list instead, so registration order and execution order match. Update the generated project template (`app/config/environment.lisp.tmpl`) and docs to use them instead of `push`.
- Also fix a stale doc claim (found while updating the docs) that hooks can be registered as bare symbols — `call-startup-hooks`' `etypecase` only accepts strings and function objects; a symbol argument actually signals a type error (verified in a running SBCL).

## Test plan
- [x] `make test` — all 67 unit tests pass, including 4 new tests in `test/environment.lisp` verifying registration order = execution order
- [x] `make e2e.test` — full scaffold → migrate → seed → serve → app-test-suite flow passes
- [x] Verified in the e2e run's server log that startup hooks now run in registration order: `startup-connection-pool` → `initialize-logger` → `initialize-table-information` (previously reversed)

## Out of scope (noted, not fixed here)
- `clails stop` runs in a fresh CLI process, so `*handler*` is always `nil` there and shutdown hooks never actually run — worth a separate issue.
- `template/project/app/config/environment.lisp.tmpl.bak`, an unused leftover file, is still tracked in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)