### PR TITLE
Deprecate HTTP-method dispatch in favor of :action-based routing

### DIFF
--- a/document/controller.md
+++ b/document/controller.md
@@ -63,6 +63,8 @@ A Controller for REST APIs that return structured data such as JSON.
 
 ### Implementing HTTP Method Handlers
 
+> **Deprecated:** `do-get` / `do-post` / `do-put` / `do-delete` are clails' original, HTTP-method-based dispatch mechanism. They still work exactly as described below and are not being removed in this release, but new code should prefer [`:action`-based routing](#action-based-routing) instead. See [Migrating from HTTP-method dispatch to `:action`-based routing](#migrating-from-http-method-dispatch-to-action-based-routing) below for why and how.
+
 Override methods corresponding to each HTTP method.
 
 ```common-lisp
@@ -218,7 +220,70 @@ In the corresponding Controller, define action-named methods instead of `do-get`
 2. Routes where only the path matches and `:method` is not specified
 3. No match → 404
 
-**Backward compatibility:** Routes without `:action` continue to dispatch to `do-get`, `do-post`, etc. as before.
+**Backward compatibility:** Routes without `:action` continue to dispatch to `do-get`, `do-post`, etc. as before. This HTTP-method dispatch mechanism is deprecated (see below) but is not being removed in this release.
+
+### Migrating from HTTP-method dispatch to `:action`-based routing
+
+clails currently supports two ways for a route to decide which controller method runs:
+
+1. **HTTP-method dispatch** (the original mechanism): the route only specifies `:path` and `:controller`, and the middleware (`clails/middleware/clails-middleware`) picks `do-get`, `do-post`, `do-put`, or `do-delete` based on the request's HTTP method, including a `_method` parameter check for POST requests (see below).
+2. **`:action`-based routing** (described above): the route specifies `:path`, `:method`, `:controller`, and `:action`, and the framework calls the method named by `:action` directly.
+
+Both keep working side by side today. **`:action`-based routing is the preferred mechanism for new code**, and existing HTTP-method-dispatch routes should be migrated over time:
+
+- **Single source of truth for the path → method mapping.** With HTTP-method dispatch, which controller method actually runs for a request is decided in two separate places: the routing table (which controller handles the path) and the middleware's HTTP-method `cond` (which of `do-get`/`do-post`/`do-put`/`do-delete` is called, plus the `_method` override). With `:action`-based routing, the `:path`, `:method`, and `:action` on a single route entry are the *only* place that mapping is declared.
+- **No `_method` spoofing needed to reach the right dispatch path.** `path-controller` matches `:action` routes directly against the request's real HTTP method and never inspects the `_method` parameter — that check exists only in the middleware's legacy fallback branch. Adding a new action to a controller therefore never requires wiring up an additional `_method` case.
+- **Multiple actions per controller without overloading a single method.** `do-get` can mean only one thing per controller. With `:action`, `index`, `show`, `new`, `edit`, etc. are each their own method on the same controller class, as the `resources` function already relies on.
+
+**Before (HTTP-method dispatch):**
+
+```common-lisp
+;; routes
+(setf clails/environment:*routing-tables*
+  '((:path "/todos"     :controller "your-app/controllers/todo-controller::<todo-controller>")
+    (:path "/todos/:id" :controller "your-app/controllers/todo-controller::<todo-controller>")))
+
+;; controller
+(defclass <todo-controller> (<web-controller>) ())
+
+(defmethod do-get ((controller <todo-controller>))
+  (set-view controller "todos/index.html" `(:todos ,(find-all))))
+
+(defmethod do-put ((controller <todo-controller>))
+  (mark-as-done (find-by-id (param controller "id")))
+  (set-redirect controller "/todos"))
+```
+
+An HTML `<form>` can only reach `do-put` above by POSTing with a hidden `_method=PUT` field, since `<form>` cannot send PUT natively.
+
+**After (`:action`-based routing):**
+
+```common-lisp
+;; routes
+(setf clails/environment:*routing-tables*
+  '((:path "/todos"     :controller "your-app/controllers/todo-controller::<todo-controller>"
+     :action "index" :method :get)
+    (:path "/todos/:id" :controller "your-app/controllers/todo-controller::<todo-controller>"
+     :action "update" :method :put)))
+
+;; controller
+(defclass <todo-controller> (<web-controller>) ())
+
+(defmethod index ((controller <todo-controller>))
+  (set-view controller "todos/index.html" `(:todos ,(find-all))))
+
+(defmethod update ((controller <todo-controller>))
+  (mark-as-done (find-by-id (param controller "id")))
+  (set-redirect controller "/todos"))
+```
+
+(The `resources` function generates exactly this shape of route table for a full set of CRUD actions — see below.)
+
+**Migration caveat for PUT/DELETE from plain HTML forms:** because `:action`-based route matching uses the request's *real* HTTP method and does not consult `_method` at all, a form that used `_method=PUT`/`_method=DELETE` to reach a legacy `do-put`/`do-delete` cannot reach a `:method :put`/`:method :delete` action route the same way — the request still arrives as a real POST, and no route in the table matches `:post` at that path. To migrate such a form, either send the request with a real PUT/DELETE (e.g. via `fetch`/`XMLHttpRequest`, or a JS-enhanced form submission), or keep a `:method :post` action for that path if you must keep supporting plain, unscripted HTML forms.
+
+**Startup warning for remaining legacy routes:** `initialize-routing-tables` emits a single warning (once per routing-table compile, e.g. at application startup — never per HTTP request) listing any routes that still lack `:action` and will fall back to HTTP-method dispatch, to help you find routes that still need migrating.
+
+No removal date has been set for the HTTP-method dispatch mechanism; it will keep working until a future release explicitly announces its removal.
 
 ### RESTful Routing with the `resources` Function
 
@@ -783,6 +848,6 @@ clails Controllers have the following features:
 4. **View Integration**: Easy view rendering with `set-view`
 5. **REST API Support**: Return JSON responses with `<rest-controller>`
 6. **Transaction Support**: Transaction management in coordination with Models
-7. **Backward Compatibility**: Traditional `do-get` / `do-post` style and new action-based style can coexist
+7. **Backward Compatibility**: Traditional `do-get` / `do-post` style and new action-based style can coexist; the traditional style is deprecated in favor of `:action`-based routing (see [Migrating from HTTP-method dispatch to `:action`-based routing](#migrating-from-http-method-dispatch-to-action-based-routing))
 
 For detailed API reference, please refer to the docstring of each function.

--- a/document/controller_ja.md
+++ b/document/controller_ja.md
@@ -63,6 +63,8 @@ JSON などの構造化データを返す REST API 用の Controller です。
 
 ### HTTP メソッドハンドラの実装
 
+> **非推奨:** `do-get` / `do-post` / `do-put` / `do-delete` は clails のもともとの、HTTP メソッドに基づくディスパッチ機構です。以下の説明どおり今後も動作し続け、このリリースで削除されることはありませんが、新しく書くコードでは代わりに[アクションベースのルーティング](#アクションベースのルーティング)を使うことを推奨します。理由と移行方法は後述の[「HTTP メソッドディスパッチから `:action` ベースのルーティングへの移行」](#http-メソッドディスパッチから-action-ベースのルーティングへの移行)を参照してください。
+
 各 HTTP メソッドに対応するメソッドをオーバーライドします。
 
 ```common-lisp
@@ -218,7 +220,70 @@ URL パス内の `:parameter-name` は自動的に抽出され、`param` 関数�
 2. パスのみ一致し、`:method` が指定されていないルート
 3. マッチなし → 404
 
-**後方互換性:** `:action` が指定されていないルートは、従来通り `do-get`、`do-post` 等にディスパッチされます。
+**後方互換性:** `:action` が指定されていないルートは、従来通り `do-get`、`do-post` 等にディスパッチされます。この HTTP メソッドディスパッチ機構は非推奨です（後述）が、このリリースで削除されることはありません。
+
+### HTTP メソッドディスパッチから `:action` ベースのルーティングへの移行
+
+clails には、ルートがどの Controller メソッドを呼ぶかを決める方法が現在2つあります。
+
+1. **HTTP メソッドディスパッチ**（もともとの機構）: ルートには `:path` と `:controller` のみを指定し、ミドルウェア（`clails/middleware/clails-middleware`）がリクエストの HTTP メソッドに基づいて `do-get`、`do-post`、`do-put`、`do-delete` のいずれかを選びます。POST リクエストに対する `_method` パラメータのチェックも含まれます（後述）。
+2. **`:action` ベースのルーティング**（前述）: ルートに `:path`、`:method`、`:controller`、`:action` を指定し、フレームワークが `:action` で指定されたメソッドを直接呼び出します。
+
+両者は現在どちらも動作しますが、**新しいコードでは `:action` ベースのルーティングを使うことを推奨**し、既存の HTTP メソッドディスパッチのルートは徐々に移行してください。
+
+- **パス → メソッドの対応関係が一箇所にまとまる。** HTTP メソッドディスパッチでは、あるリクエストで実際にどの Controller メソッドが呼ばれるかは、ルーティングテーブル（どの Controller がそのパスを処理するか）とミドルウェアの HTTP メソッド用 `cond`（`do-get`/`do-post`/`do-put`/`do-delete` のどれを呼ぶか、および `_method` による上書き）という2箇所に分かれて決まります。`:action` ベースのルーティングでは、1つのルートエントリの `:path`、`:method`、`:action` だけがその対応関係の唯一の定義場所になります。
+- **正しいディスパッチ先に到達するために `_method` の偽装が不要。** `path-controller` は `:action` ルートをリクエストの実際の HTTP メソッドと直接照合し、`_method` パラメータは一切参照しません。このチェックが存在するのは、ミドルウェアの従来（レガシー）フォールバック分岐だけです。そのため、Controller に新しいアクションを追加するときに `_method` のケースを追加で配線する必要がありません。
+- **1つのメソッドに複数の意味を持たせずに、Controller ごとに複数のアクションを定義できる。** `do-get` は Controller ごとに1つの意味しか持てません。`:action` を使えば、`resources` 関数がすでに前提としているように、`index`、`show`、`new`、`edit` などをそれぞれ同じ Controller クラス上の別々のメソッドとして定義できます。
+
+**移行前（HTTP メソッドディスパッチ）:**
+
+```common-lisp
+;; ルート定義
+(setf clails/environment:*routing-tables*
+  '((:path "/todos"     :controller "your-app/controllers/todo-controller::<todo-controller>")
+    (:path "/todos/:id" :controller "your-app/controllers/todo-controller::<todo-controller>")))
+
+;; Controller
+(defclass <todo-controller> (<web-controller>) ())
+
+(defmethod do-get ((controller <todo-controller>))
+  (set-view controller "todos/index.html" `(:todos ,(find-all))))
+
+(defmethod do-put ((controller <todo-controller>))
+  (mark-as-done (find-by-id (param controller "id")))
+  (set-redirect controller "/todos"))
+```
+
+HTML の `<form>` は PUT をネイティブに送信できないため、上記の `do-put` には通常、`_method=PUT` の隠しフィールドを付けて POST することでしか到達できません。
+
+**移行後（`:action` ベースのルーティング）:**
+
+```common-lisp
+;; ルート定義
+(setf clails/environment:*routing-tables*
+  '((:path "/todos"     :controller "your-app/controllers/todo-controller::<todo-controller>"
+     :action "index" :method :get)
+    (:path "/todos/:id" :controller "your-app/controllers/todo-controller::<todo-controller>"
+     :action "update" :method :put)))
+
+;; Controller
+(defclass <todo-controller> (<web-controller>) ())
+
+(defmethod index ((controller <todo-controller>))
+  (set-view controller "todos/index.html" `(:todos ,(find-all))))
+
+(defmethod update ((controller <todo-controller>))
+  (mark-as-done (find-by-id (param controller "id")))
+  (set-redirect controller "/todos"))
+```
+
+（`resources` 関数は、CRUD の一式についてまさにこの形のルートテーブルを生成します。詳細は後述します。）
+
+**プレーンな HTML フォームからの PUT/DELETE 移行時の注意点:** `:action` ベースのルートマッチングはリクエストの*実際の* HTTP メソッドを使い、`_method` は一切参照しません。そのため、`_method=PUT`/`_method=DELETE` を使って従来の `do-put`/`do-delete` に到達していたフォームは、同じ方法では `:method :put`/`:method :delete` のアクションルートに到達できません — リクエストは実際には POST のまま届き、そのパスに対して `:post` にマッチするルートが存在しないためです。このようなフォームを移行するには、実際に PUT/DELETE を送信する（例えば `fetch`/`XMLHttpRequest`、または JavaScript で拡張したフォーム送信を使う）か、スクリプトなしの素の HTML フォームをサポートし続ける必要がある場合は、そのパス用に `:method :post` のアクションを残しておいてください。
+
+**起動時の警告:** `initialize-routing-tables` は、ルーティングテーブルのコンパイル1回につき1回だけ（たとえばアプリケーション起動時に1回、HTTP リクエストごとではありません）、`:action` が指定されておらず HTTP メソッドディスパッチにフォールバックするルートを一覧にした警告を1つ出力します。まだ移行が必要なルートを見つける助けになります。
+
+HTTP メソッドディスパッチ機構の削除時期は現時点では決まっていません。将来のリリースで明示的に削除がアナウンスされるまでは動作し続けます。
 
 ### `resources` 関数による RESTful ルーティング
 
@@ -791,6 +856,6 @@ clails の Controller は以下の特徴を持ちます。
 4. **View の統合**: `set-view` による簡単な View レンダリング
 5. **REST API サポート**: `<rest-controller>` による JSON レスポンスの返却
 6. **トランザクション対応**: Model と連携したトランザクション管理
-7. **後方互換性**: 従来の `do-get` / `do-post` 方式と新しいアクション方式が共存可能
+7. **後方互換性**: 従来の `do-get` / `do-post` 方式と新しいアクション方式が共存可能。従来方式は非推奨であり、`:action` ベースのルーティングへの移行を推奨します（[「HTTP メソッドディスパッチから `:action` ベースのルーティングへの移行」](#http-メソッドディスパッチから-action-ベースのルーティングへの移行)を参照）
 
 詳細な API リファレンスについては、各関数の docstring を参照してください。

--- a/src/controller/base-controller.lisp
+++ b/src/controller/base-controller.lisp
@@ -119,8 +119,38 @@
    "
   (gethash key (slot-value controller 'params)))
 
+;;; ------------------------------------------------------------------
+;;; DEPRECATED: HTTP-method dispatch (do-get / do-post / do-put / do-delete)
+;;;
+;;; These four generic functions are the legacy action-dispatch mechanism:
+;;; when a route entry in *routing-tables* does not specify :action, the
+;;; controller middleware (clails/middleware/clails-middleware) falls back
+;;; to calling one of these methods based on the incoming HTTP method,
+;;; including "_method" parameter spoofing (a hidden form field) so that
+;;; HTML <form> POSTs can emulate PUT/DELETE.
+;;;
+;;; New code should prefer :action-based routing (specify :action and
+;;; :method on the route entry, and define a method named after the
+;;; action instead of do-get/do-post/do-put/do-delete). :action-based
+;;; routing keeps the path -> method mapping declared in one place (the
+;;; routing table) rather than split across the routing table and an
+;;; implicit HTTP-method convention, and it does not need the _method
+;;; spoofing hack since each action gets its own explicit :method entry.
+;;;
+;;; The do-get/do-post/do-put/do-delete mechanism is not being removed by
+;;; this change and continues to work exactly as before; it is marked here
+;;; as deprecated in favor of :action-based routing. See
+;;; document/controller.md ("Migrating from HTTP-method dispatch to
+;;; :action-based routing") for a migration guide.
+;;; ------------------------------------------------------------------
+
 (defgeneric do-get (controller)
   (:documentation "Handle HTTP GET request.
+
+   DEPRECATED: this is part of the legacy HTTP-method dispatch mechanism.
+   Prefer :action-based routing (see document/controller.md) for new code.
+   This method keeps working unchanged and is not scheduled for removal
+   in this change.
 
    Default implementation signals a 404/not-found error.
    Override this method to implement GET request handling.
@@ -137,6 +167,11 @@
 (defgeneric do-post (controller)
   (:documentation "Handle HTTP POST request.
 
+   DEPRECATED: this is part of the legacy HTTP-method dispatch mechanism.
+   Prefer :action-based routing (see document/controller.md) for new code.
+   This method keeps working unchanged and is not scheduled for removal
+   in this change.
+
    Default implementation signals a 404/not-found error.
    Override this method to implement POST request handling.
 
@@ -152,6 +187,13 @@
 (defgeneric do-put (controller)
   (:documentation "Handle HTTP PUT request.
 
+   DEPRECATED: this is part of the legacy HTTP-method dispatch mechanism.
+   Prefer :action-based routing (see document/controller.md) for new code.
+   Note that browsers cannot send PUT from an HTML <form>, so this is
+   normally reached via the \"_method\" parameter-spoofing hack on a POST
+   request; :action-based routing does not need that hack. This method
+   keeps working unchanged and is not scheduled for removal in this change.
+
    Default implementation signals a 404/not-found error.
    Override this method to implement PUT request handling.
 
@@ -166,6 +208,13 @@
 
 (defgeneric do-delete (controller)
   (:documentation "Handle HTTP DELETE request.
+
+   DEPRECATED: this is part of the legacy HTTP-method dispatch mechanism.
+   Prefer :action-based routing (see document/controller.md) for new code.
+   Note that browsers cannot send DELETE from an HTML <form>, so this is
+   normally reached via the \"_method\" parameter-spoofing hack on a POST
+   request; :action-based routing does not need that hack. This method
+   keeps working unchanged and is not scheduled for removal in this change.
 
    Default implementation signals a 404/not-found error.
    Override this method to implement DELETE request handling.
@@ -360,7 +409,32 @@
                           ;; Priority 3: Default behavior
                           (t
                            (append tbl
-                                   (create-scanner-from-uri-path path))))))))
+                                   (create-scanner-from-uri-path path)))))))
+  (warn-on-legacy-dispatch-routes))
+
+
+(defun warn-on-legacy-dispatch-routes ()
+  "Emit a single warning listing any routes that rely on the legacy
+   HTTP-method dispatch mechanism (do-get/do-post/do-put/do-delete)
+   instead of specifying :action.
+
+   This is a deprecation notice only: it does not change how routes are
+   matched or dispatched. It is emitted once per call to
+   initialize-routing-tables (i.e. once per routing-table compile, such
+   as at application startup), never per HTTP request, so it will not
+   spam logs in production.
+
+   @return [nil]
+   "
+  (let ((legacy-paths (loop for r in *router*
+                             unless (getf r :action)
+                             collect (getf r :path))))
+    (when legacy-paths
+      (format *error-output*
+              "Warning: ~D route(s) do not specify :action and will dispatch via the deprecated do-get/do-post/do-put/do-delete mechanism: ~{~A~^, ~}. Consider migrating to :action-based routing; see document/controller.md (\"Migrating from HTTP-method dispatch to :action-based routing\") for a guide.~%"
+              (length legacy-paths)
+              legacy-paths)))
+  (values))
 
 
 (defun create-scanner-from-uri-path (path)

--- a/test/controller/base-controller.lisp
+++ b/test/controller/base-controller.lisp
@@ -418,3 +418,49 @@
 
       ;; GET /nonexistent -> nil
       (ok (null (clails/controller/base-controller::path-controller "/nonexistent" :get))))))
+
+
+(defclass <test-action-only-controller> (<base-controller>)
+  ())
+
+(defclass <test-legacy-only-controller> (<base-controller>)
+  ())
+
+(deftest legacy-dispatch-deprecation-warning-test
+  (testing "a route table using only :action-based routes produces no deprecation warning"
+    (let* ((test-tables '((:path "/action-only"
+                           :controller "clails-test/controller/base-controller::<test-action-only-controller>"
+                           :action "index"
+                           :method :get)))
+           (*routing-tables* test-tables)
+           (warning-output (make-string-output-stream)))
+      (let ((*error-output* warning-output))
+        (initialize-routing-tables))
+      (ok (string= (get-output-stream-string warning-output) ""))))
+
+  (testing "a route relying on HTTP-method dispatch (no :action) produces a deprecation warning"
+    (let* ((test-tables '((:path "/legacy-only"
+                           :controller "clails-test/controller/base-controller::<test-legacy-only-controller>")))
+           (*routing-tables* test-tables)
+           (warning-output (make-string-output-stream)))
+      (let ((*error-output* warning-output))
+        (initialize-routing-tables))
+      (let ((warning-text (get-output-stream-string warning-output)))
+        (ok (ppcre:scan "deprecated" warning-text))
+        (ok (ppcre:scan "/legacy-only" warning-text)))))
+
+  (testing "the warning fires at most once per routing-table compile, regardless of request volume"
+    (let* ((test-tables '((:path "/legacy-only"
+                           :controller "clails-test/controller/base-controller::<test-legacy-only-controller>")))
+           (*routing-tables* test-tables)
+           (warning-output (make-string-output-stream)))
+      (let ((*error-output* warning-output))
+        (initialize-routing-tables)
+        ;; Simulate a burst of request-time route lookups; none of these
+        ;; should emit additional warnings, since the warning is tied to
+        ;; compiling the routing table, not to dispatching a request.
+        (dotimes (i 100)
+          (clails/controller/base-controller::path-controller "/legacy-only" :get)))
+      (let* ((warning-text (get-output-stream-string warning-output))
+             (occurrences (length (ppcre:all-matches-as-strings "deprecated" warning-text))))
+        (ok (= occurrences 1))))))


### PR DESCRIPTION
Closes #160

## Summary

- Controllers can currently dispatch either through `:action`-based routes (calling the named method directly) or through the older HTTP-method dispatch mechanism (`do-get`/`do-post`/`do-put`/`do-delete`, chosen by the middleware based on the request's HTTP method, including `_method` parameter spoofing for PUT/DELETE from HTML forms). Both mechanisms have to be documented, tested, and maintained, and new users have to learn which one applies to a given route.
- This PR is documentation + soft-deprecation only, as scoped in #160 — it does **not** remove or change the runtime behavior of either dispatch mechanism.
- Added deprecation docstrings/comments to `do-get`/`do-post`/`do-put`/`do-delete` in `src/controller/base-controller.lisp`, pointing to `:action`-based routing.
- Added a one-time warning emitted by `initialize-routing-tables` (i.e. once per routing-table compile, such as at application startup) listing any routes still relying on HTTP-method dispatch. It is **not** emitted per HTTP request.
- Added a "Migrating from HTTP-method dispatch to `:action`-based routing" section to `document/controller.md` and `document/controller_ja.md`, with a before/after example and the concrete reasons `:action`-based routing is preferred, verified against the actual code:
  - The path → method mapping lives in one place (the route entry) instead of being split across the routing table and the middleware's HTTP-method `cond`.
  - `path-controller` matches `:action` routes against the request's *real* HTTP method and never inspects the `_method` parameter — that check only exists in the legacy fallback branch — so no `_method` spoofing wiring is needed for `:action` routes.
  - A migration caveat is called out explicitly: because `:action`-based matching doesn't consult `_method`, a plain HTML form using `_method=PUT`/`DELETE` to reach a legacy `do-put`/`do-delete` cannot reach a `:method :put`/`:method :delete` action route the same way; migrating such a form requires a real PUT/DELETE request (e.g. via `fetch`) or keeping a `:method :post` action.
- Did **not** change what `template/generate/controller.lisp.tmpl` or the e2e todo app scaffold generates (both still use `do-get`/`do-post`/`do-put`) — changing scaffolding defaults is out of scope for this issue.
- No specific removal version/date is committed to in the docs, per the issue's scope note. Suggestion for the maintainer to consider separately: given this is a "mark as deprecated" step, a natural follow-up would be to actually remove the legacy dispatch mechanism in a subsequent major/minor version once existing apps have had a chance to migrate — happy to open a follow-up issue if useful.

## Test plan

- [x] Added `legacy-dispatch-deprecation-warning-test` to `test/controller/base-controller.lisp` covering: (a) an `:action`-only routing table produces no warning, (b) a route relying on HTTP-method dispatch produces a warning mentioning "deprecated" and the route path, (c) the warning fires exactly once per `initialize-routing-tables` call regardless of how many times `path-controller` is subsequently called (simulated 100 lookups).
- [x] Ran the full `clails-test/controller/base-controller` suite via `rove` directly (all existing tests plus the new ones pass, 100%).
- [x] Ran `make test` end-to-end via Docker; the run reached the same pre-existing MySQL/PostgreSQL connectivity failures unrelated to this change (shared Docker infrastructure in this sandbox has multiple concurrent worktree sessions colliding on fixed container names) — the controller test suite itself (the only suite touched by this change) passed. Recommend re-running `make test` / `make e2e.test` in CI to confirm end-to-end, since this sandbox's Docker networking made a fully clean run unreliable.
- [x] Did not modify scaffolding (`template/generate/controller.lisp.tmpl`) or the e2e todo app controller, so `make e2e.test` behavior is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)