### PR TITLE
Validate migration filenames against the timestamp-prefix convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         CLAILS_MIGRATION_DIR_0011: ${{ github.workspace }}/test/data/0011-bulk-insert-test
         CLAILS_MIGRATION_DIR_0012: ${{ github.workspace }}/test/data/0012-type-conversion-test
         CLAILS_MIGRATION_DIR_0013: ${{ github.workspace }}/test/data/0013-todo-tag-junction-test
+        CLAILS_MIGRATION_DIR_0014: ${{ github.workspace }}/test/data/0014-migration-filename-validation-test
         CLAILS_SQLITE3_DATABASE: ${{ github.workspace }}
         CLAILS_MYSQL_DATABASE: clails_test
         CLAILS_MYSQL_USERNAME: root

--- a/clails-test.asd
+++ b/clails-test.asd
@@ -28,6 +28,7 @@
                #:clails-test/model/optimistic-lock
                #:clails-test/model/default-value
                #:clails-test/model/migration
+               #:clails-test/model/migration-filename-validation
                #:clails-test/model/transaction
                #:clails-test/model/transaction/transaction-sqlite3
                #:clails-test/model/transaction/transaction-mysql

--- a/document/model.md
+++ b/document/model.md
@@ -27,6 +27,15 @@ YYYYmmdd-HHMMSS-description.lisp
 
 Example: `20240101-120000-create-users-table.lisp`
 
+Migration files are loaded in filename order, so the timestamp prefix determines
+the order in which migrations are applied. At `db:migrate` time, each filename
+under `db/migrate/` is checked against the expected timestamp-prefix pattern
+(an 8-digit date and 6-digit time, separated by `-` or `_`, followed by a name,
+e.g. `20240101-120000-create-users-table.lisp` or
+`20240101120000_create-users-table.lisp`). A file that doesn't match prints a
+warning naming the file and the expected pattern; it is still loaded, but its
+position in the load order relative to other migrations is not guaranteed.
+
 ### Creating Tables
 
 ```common-lisp

--- a/document/model_ja.md
+++ b/document/model_ja.md
@@ -27,6 +27,14 @@ YYYYmmdd-HHMMSS-description.lisp
 
 例: `20240101-120000-create-users-table.lisp`
 
+Migration ファイルはファイル名順にロードされるため、タイムスタンプ部分が
+Migration の適用順序を決定します。`db:migrate` 実行時、`db/migrate/` 配下の
+各ファイル名は期待されるタイムスタンプ形式(8桁の日付と6桁の時刻を `-` または
+`_` で区切り、その後に名前が続く形式。例: `20240101-120000-create-users-table.lisp`
+や `20240101120000_create-users-table.lisp`)と照合されます。一致しないファイルは
+ファイル名と期待される形式を示す警告が表示されますが、そのままロードは続行され
+ます。ただし、他の Migration との読み込み順序は保証されません。
+
 ### テーブル作成
 
 ```common-lisp

--- a/src/model/migration.lisp
+++ b/src/model/migration.lisp
@@ -34,6 +34,7 @@
            #:migrate-down-version
            #:db-rollback
            #:check-type-valid
+           #:valid-migration-filename-p
            #:db-seed))
 (in-package #:clails/model/migration)
 
@@ -266,9 +267,31 @@
   (with-db-connection-direct (connection)
     (ensure-migration-table-impl *database-type* connection)))
 
+(defparameter *migration-filename-scanner*
+  (cl-ppcre:create-scanner "^\\d{8}-?\\d{6}[-_].+\\.lisp$")
+  "Scanner for the expected migration filename convention: an 8-digit date,
+   optionally followed by a hyphen, then a 6-digit time, a separator
+   (- or _), and a name, e.g. \"20250612-093015-create-users-table.lisp\"
+   or \"20250612093015_create-users-table.lisp\".")
+
+(defun valid-migration-filename-p (filename)
+  "Check whether FILENAME follows the expected timestamp-prefixed migration
+   filename convention.
+
+   @param filename [string] Basename to check, e.g. \"20250612-093015-create-users-table.lisp\"
+   @return [boolean] T if filename matches the expected pattern, NIL otherwise
+   "
+  (not (null (cl-ppcre:scan *migration-filename-scanner* filename))))
+
 (defun load-migration-files ()
   (let ((files (directory (format NIL "~A/db/migrate/**/*.lisp" *migration-base-dir*))))
     (dolist (file files)
+      (let ((filename (file-namestring file)))
+        (unless (valid-migration-filename-p filename)
+          (format t "WARNING: migration file ~A does not match the expected naming convention.~%" filename)
+          (format t "         Expected a timestamp prefix, e.g. 20250612-093015-description.lisp~%")
+          (format t "         or 20250612093015_description.lisp.~%")
+          (format t "         Loading it anyway, but its position in migration load order is not guaranteed.~%")))
       (format t "loading migration file: ~A" file)
       (load file)
       (format t " ... done~%"))))

--- a/test/data/0014-migration-filename-validation-test/db/migrate/20250101-000000-create-widgets-table.lisp
+++ b/test/data/0014-migration-filename-validation-test/db/migrate/20250101-000000-create-widgets-table.lisp
@@ -1,0 +1,9 @@
+(in-package #:clails-test/model/db/migration-filename-validation)
+
+(defmigration "20250101-000000-create-widgets-table"
+  (:up #'(lambda (conn)
+           (create-table conn :table "widgets"
+                              :columns '(("name" :type :string
+                                                 :not-null T))))
+   :down #'(lambda (conn)
+             (drop-table conn :table "widgets"))))

--- a/test/data/0014-migration-filename-validation-test/db/migrate/badname.lisp
+++ b/test/data/0014-migration-filename-validation-test/db/migrate/badname.lisp
@@ -1,0 +1,11 @@
+(in-package #:clails-test/model/db/migration-filename-validation)
+
+;; Intentionally does not follow the <timestamp>-<name>.lisp / <timestamp>_<name>.lisp
+;; naming convention, to exercise db-migrate's filename validation warning.
+(defmigration "badname-migration"
+  (:up #'(lambda (conn)
+           (create-table conn :table "gadgets"
+                              :columns '(("name" :type :string
+                                                 :not-null T))))
+   :down #'(lambda (conn)
+             (drop-table conn :table "gadgets"))))

--- a/test/model/migration-filename-validation.lisp
+++ b/test/model/migration-filename-validation.lisp
@@ -1,0 +1,115 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/model/migration-filename-validation
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:with-db-connection-direct)
+  (:import-from #:clails/model/migration
+                #:db-create
+                #:db-migrate
+                #:valid-migration-filename-p))
+
+(defpackage #:clails-test/model/db/migration-filename-validation
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:drop-table))
+
+(in-package #:clails-test/model/migration-filename-validation)
+
+
+(setup
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0014" "/app/test/data/0014-migration-filename-validation-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (db-create)
+  (clean-test-database)
+  (startup-connection-pool))
+
+(teardown
+  (clean-test-database)
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (shutdown-connection-pool))
+
+
+;;; Helper functions
+
+(defun clean-test-database ()
+  "Drop all tables except migration table, then clean migration table."
+  (with-db-connection-direct (connection)
+    (let* ((tables-query (dbi:prepare connection "show tables"))
+           (tables-result (dbi:execute tables-query))
+           (tables (loop for row = (dbi:fetch tables-result)
+                        while row
+                        collect (getf row :|Tables_in_clails_test|))))
+      (dolist (table tables)
+        (unless (string= table "migration")
+          (dbi:do-sql connection (format nil "drop table if exists ~A" table))))
+      (dbi:do-sql connection "delete from migration"))))
+
+(defun get-migration-names (connection)
+  "Get all migration names from the migration table."
+  (let ((result (dbi-cp:fetch-all
+                  (dbi-cp:execute
+                    (dbi-cp:prepare connection "select migration_name from migration order by migration_name")
+                    '()))))
+    (mapcar #'(lambda (row) (getf row :|migration_name|)) result)))
+
+
+;;; Test: valid-migration-filename-p (pure predicate, no database needed)
+
+(deftest valid-migration-filename-p-test
+  (testing "valid-migration-filename-p accepts and rejects filenames as expected"
+    (ok (valid-migration-filename-p "20250612-093015-create-users-table.lisp")
+        "hyphenated date-time-name convention (as documented) is valid")
+    (ok (valid-migration-filename-p "20250612093015_create-users-table.lisp")
+        "compact 14-digit timestamp with underscore separator (as gen-unique-name produces) is valid")
+    (ok (valid-migration-filename-p "20250612093015-create-users-table.lisp")
+        "compact 14-digit timestamp with hyphen separator is valid")
+    (ok (not (valid-migration-filename-p "create-users-table.lisp"))
+        "filename with no timestamp prefix at all is invalid")
+    (ok (not (valid-migration-filename-p "2025061-093015-create-users-table.lisp"))
+        "filename with a truncated date part is invalid")
+    (ok (not (valid-migration-filename-p "20250612-09301-create-users-table.lisp"))
+        "filename with a truncated time part is invalid")
+    (ok (not (valid-migration-filename-p "20250612093015create-users-table.lisp"))
+        "filename missing a separator before the name is invalid")
+    (ok (not (valid-migration-filename-p "20250612-093015-create-users-table.txt"))
+        "non-.lisp extension is invalid")))
+
+
+;;; Test: db-migrate warns about, but still loads, a badly-named migration file
+
+(deftest db-migrate-warns-on-bad-filename-test
+  (testing "db-migrate warns about a migration file with a bad name but still applies it"
+    (clean-test-database)
+    (let ((output (with-output-to-string (*standard-output*)
+                    (db-migrate))))
+      (ok (search "badname.lisp" output)
+          "warning output should mention the badly-named migration file")
+      (ok (search "does not match the expected naming convention" output)
+          "warning output should explain the problem")
+      (ok (not (search "20250101-000000-create-widgets-table.lisp does not match" output))
+          "warning should not be emitted for the well-named migration file"))
+
+    (with-db-connection-direct (connection)
+      (let ((migrations (get-migration-names connection)))
+        (ok (= 2 (length migrations))
+            "both the well-named and badly-named migrations should still be applied")
+        (ok (member "20250101-000000-create-widgets-table" migrations :test #'string=)
+            "the well-named migration should be applied")
+        (ok (member "badname-migration" migrations :test #'string=)
+            "the badly-named migration should still be applied despite the warning")))))


### PR DESCRIPTION
Closes #155

## Summary

Migration files under `db/migrate/**/*.lisp` are not ASDF components; they're
discovered via `(directory ...)` and `load`ed in filename lexicographic order,
which is only correct if every filename actually follows the intended
timestamp-prefix convention. Nothing validated that, so a misnamed file
(wrong prefix format, typo, missing separator, etc.) could silently apply out
of order with no warning.

This PR adds filename validation only, per the issue's scoping — it does not
change how applied migrations are recorded/tracked (that's a separate, larger
design question left for a future issue).

- Added `valid-migration-filename-p` in `src/model/migration.lisp`, checking
  each filename against a pattern for an 8-digit date + 6-digit time,
  separated by `-` or `_`, followed by a name and `.lisp`
  (e.g. `20240101-120000-create-users-table.lisp` or
  `20240101120000_create-users-table.lisp`).
- `load-migration-files` now prints a warning naming the offending file and
  the expected pattern for any file that doesn't match, but **still loads
  it** — it does not abort the run or skip the file.
- Updated `document/model.md` / `model_ja.md` to mention the check.

### Design call: warn-and-still-load, not hard-error or skip

I considered three options:
- **Hard error** — safest in theory, but would halt an entire `db:migrate`
  run over one bad filename, potentially on someone's already-working
  project.
- **Warn-and-skip** — avoids the ordering problem but is arguably worse: a
  skipped migration means later migrations could get applied against a
  schema that's silently missing an earlier change, which is a harder
  failure mode to notice than a printed warning.
- **Warn, but still load** (chosen) — matches the framework's existing
  precedent (`clails/project/generate:check-unregistered-models`, which warns
  rather than erroring for a similar "loose convention" problem) and keeps
  today's behavior fully backward compatible: every migration that used to
  load still loads. The only change is visibility — a clear warning naming
  the file and the expected pattern, noting that its position in the load
  order isn't guaranteed.

### Note on an existing convention mismatch discovered while implementing this

While confirming the "expected format" against the actual generator code
(`gen-unique-name`/`current-datetime` in `src/project/generate.lisp`), I found
the generator literally produces `<14-digit-timestamp>_<name>.lisp` (no
separator between date and time, `_` before the name) — e.g.
`20260912040003_todo.lisp` (confirmed live via the e2e test's generated
project). This differs from the convention documented in `model.md`/`model_ja.md`
and used by every existing test fixture under `test/data/*/db/migrate/`:
`YYYYmmdd-HHMMSS-description.lisp`. Both were already in real use in this
repo, so the validation pattern here intentionally accepts both forms rather
than picking a side — I didn't touch the generator itself, since reconciling
that mismatch felt like it belongs in its own issue/PR rather than folded into
this one.

## Test plan

- [x] `make test` — full suite passes (67/67 test groups), including two new
      test files/deftests:
  - `valid-migration-filename-p-test`: unit coverage of the predicate against
    both valid conventions and several invalid shapes (truncated
    date/time, missing separator, no timestamp, wrong extension).
  - `db-migrate-warns-on-bad-filename-test`: integration test using a
    dedicated fixture (`test/data/0014-migration-filename-validation-test/`)
    with one well-named and one intentionally badly-named migration file,
    asserting the warning is printed for the bad file only, and that both
    migrations still get applied.
  - Verified the regex against every filename currently under
    `test/data/*/db/migrate/` — all pass without triggering a false warning.
- [x] `make e2e.test` — full scaffold → migrate → seed → serve flow passes;
      confirmed the real generator-produced filename
      (`20260912040003_todo.lisp`) loads cleanly with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)