### PR TITLE
[E-1/F-1] Implement the console command

### DIFF
--- a/document/command.md
+++ b/document/command.md
@@ -72,6 +72,7 @@ clails --help
 | `clails new` | Create a new project |
 | `clails server` | Start web server |
 | `clails stop` | Stop web server |
+| `clails console` | Start an interactive console (REPL) |
 
 ### Code Generation
 
@@ -237,6 +238,64 @@ clails stop
 ```bash
 clails stop
 ```
+
+### `clails console` - Start an Interactive Console
+
+Boots the project's environment (configuration, DB connection, models -- the
+same `load-project` initialization path used by `server`/`db:*`/`test`) and
+then drops you into an interactive Lisp REPL, similar to `rails console`.
+
+#### Syntax
+
+```bash
+clails console
+```
+
+#### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--help` | `-h` | Show this help message |
+
+#### What's available in the REPL
+
+- The REPL runs in the project's `<project>-DB` package -- the same package
+  `db/seeds.lisp` and migration files run in. It already `:use`s
+  `clails/model` and imports every model package registered in
+  `app/models/package.lisp`, so registered models can be referenced the same
+  way `db/seeds.lisp` does:
+
+  ```common-lisp
+  todoapp-DB> (save (make-record 'todoapp/models/user:<user> :name "alice" :email "alice@example.com"))
+  todoapp-DB> (execute-query (query todoapp/models/user:<user> :as :user) nil)
+  ```
+
+- The database connection pool is started before the REPL begins and shut
+  down automatically when you leave, so model queries and saves work exactly
+  as they do inside a running server.
+- The REPL supports the standard `*`, `**`, `***` history variables for the
+  last few results.
+
+#### Examples
+
+```bash
+# Start an interactive console
+clails console
+
+# Leave the console
+todoapp-DB> (quit)
+todoapp-DB> (exit)
+# or press Ctrl-D
+```
+
+#### Behavior
+
+1. Load the project environment via `load-project` (config, DB settings) and
+   `load-db-package` (the `<project>-DB` package), exactly as `db:*` commands do
+2. Start the DB connection pool and load table metadata
+3. Read, evaluate, and print Lisp forms from standard input in a loop until
+   `(quit)`, `(exit)`, `:quit`, `:exit`, or end-of-input (Ctrl-D)
+4. Shut down the DB connection pool on the way out
 
 ---
 

--- a/document/command_ja.md
+++ b/document/command_ja.md
@@ -72,6 +72,7 @@ clails --help
 | `clails new` | 新しいプロジェクトを作成 |
 | `clails server` | Web サーバーを起動 |
 | `clails stop` | Web サーバーを停止 |
+| `clails console` | インタラクティブコンソール（REPL）を起動 |
 
 ### コード生成
 
@@ -237,6 +238,65 @@ clails stop
 ```bash
 clails stop
 ```
+
+### `clails console` - インタラクティブコンソールを起動
+
+プロジェクトの環境（設定、DB 接続、Model）を `server`/`db:*`/`test` と同じ
+`load-project` 初期化パスで読み込んだ後、`rails console` と同様にインタラク
+ティブな Lisp REPL を起動します。
+
+#### 書式
+
+```bash
+clails console
+```
+
+#### オプション
+
+| オプション | 短縮形 | 説明 |
+|-----------|-------|------|
+| `--help` | `-h` | このヘルプメッセージを表示 |
+
+#### REPL で使えるもの
+
+- REPL はプロジェクトの `<project>-DB` パッケージ上で動作します。これは
+  `db/seeds.lisp` や Migration ファイルが実行されるのと同じパッケージで、
+  すでに `clails/model` を `:use` しており、`app/models/package.lisp` に
+  登録済みの Model パッケージもすべて import 済みです。そのため、
+  `db/seeds.lisp` と同じ書き方で登録済みの Model を参照できます。
+
+  ```common-lisp
+  todoapp-DB> (save (make-record 'todoapp/models/user:<user> :name "alice" :email "alice@example.com"))
+  todoapp-DB> (execute-query (query todoapp/models/user:<user> :as :user) nil)
+  ```
+
+- REPL を開始する前に DB コネクションプールが起動され、終了時に自動的に
+  シャットダウンされるため、実行中のサーバーと同じように Model の
+  検索・保存が行えます。
+- `*`、`**`、`***` という、直前の実行結果を参照する標準的な REPL の
+  履歴変数も利用できます。
+
+#### 使用例
+
+```bash
+# インタラクティブコンソールを起動
+clails console
+
+# コンソールを終了する
+todoapp-DB> (quit)
+todoapp-DB> (exit)
+# または Ctrl-D を押す
+```
+
+#### 動作
+
+1. `load-project`（設定、DB 設定）と `load-db-package`（`<project>-DB`
+   パッケージ）でプロジェクトの環境を読み込む（`db:*` 系コマンドと同様）
+2. DB コネクションプールを起動し、テーブルのメタ情報を読み込む
+3. 標準入力から Lisp の式を読み取り、評価し、結果を表示するループを、
+   `(quit)`、`(exit)`、`:quit`、`:exit`、または入力終了（Ctrl-D）まで
+   繰り返す
+4. 終了時に DB コネクションプールをシャットダウンする
 
 ---
 

--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -35,6 +35,7 @@ exec ros -Q -- $0 "$@"
   (format t "  test [packages...]                Run tests~%")
   (format t "  server                            Start web server~%")
   (format t "  stop                              Stop web server~%")
+  (format t "  console                           Start an interactive console~%")
   (format t "~%")
   (format t "Run 'clails COMMAND --help' for more information on a command.~%"))
 
@@ -149,6 +150,19 @@ exec ros -Q -- $0 "$@"
   (format t "~%")
   (format t "Examples:~%")
   (format t "  clails stop~%"))
+
+(defun help/console ()
+  (format t "Usage: clails console~%~%")
+  (format t "Start an interactive console (REPL) for the application.~%~%")
+  (format t "Boots the project environment (config, DB connection, models) the same~%")
+  (format t "way 'clails server' does, then drops you into a Lisp REPL running in the~%")
+  (format t "project's <project>-DB package, so registered models are available the~%")
+  (format t "same way db/seeds.lisp uses them.~%~%")
+  (format t "Options:~%")
+  (format t "  -h, --help                Show this help message~%")
+  (format t "~%")
+  (format t "Examples:~%")
+  (format t "  clails console~%"))
 
 (defun help/task ()
   (format t "Usage: clails task [TASK] [OPTIONS]~%~%")
@@ -554,6 +568,16 @@ exec ros -Q -- $0 "$@"
     (uiop:quit 0))
   (load-project)
   (clails/cmd:stop))
+
+(define-command "console" (&key (help :short-option "h"
+                                      :long-option "help"))
+  (:help-function #'help/console)
+  (when help
+    (help/console)
+    (uiop:quit 0))
+  (load-project)
+  (load-db-package)
+  (clails/cmd:console))
 
 (define-command "task" (args &key (list :short-option "l"
                                         :long-option "list")

--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -243,14 +243,95 @@
     (shutdown-connection-pool)))
 
 
+(defparameter +console-quit-symbols+ '("QUIT" "EXIT")
+  "Symbol names that end the interactive console when read as a bare symbol
+   or as a zero-argument call, e.g. QUIT, (QUIT), :QUIT, EXIT, (EXIT), :EXIT.
+   Matched by name rather than by symbol identity so it works no matter which
+   package the console's *package* happens to be bound to.")
+
+(defun console-quit-form-p (form)
+  "Return T when FORM should end the console's read-eval-print loop.
+
+   @param form [t] Form read from the console's input stream
+   @return [boolean] T if FORM is a quit/exit request
+   "
+  (flet ((quit-symbol-p (x)
+           (and (symbolp x)
+                (member (symbol-name x) +console-quit-symbols+ :test #'string=))))
+    (or (quit-symbol-p form)
+        (and (consp form)
+             (null (cdr form))
+             (quit-symbol-p (car form))))))
+
+(defun console-repl-package ()
+  "Determine which package the interactive console should read/eval forms in.
+
+   Prefers <project>-DB: the package db/seeds.lisp and migration files run
+   in, which already :use's clails/model and imports every model package
+   registered in app/models/package.lisp (see load-db-package in
+   roswell/clails.ros, which loads db/package.lisp before calling console).
+   Falls back to CL-USER if that package is not present for some reason.
+
+   @return [package] Package to bind *package* to for the console session
+   "
+  (or (find-package (string-upcase (format nil "~A-DB" *project-name*)))
+      (find-package :cl-user)))
+
 (defun console ()
   "Start an interactive console for the application.
 
-   Not yet implemented.
+   Assumes the project environment (config, DB settings, models) has already
+   been booted via the same load-project path used by server/db:*/test --
+   see roswell/clails.ros, which calls load-project (and load-db-package)
+   before invoking this function. Starts the DB connection pool and loads
+   table metadata, then hands control to a simple read-eval-print loop
+   running in the project's <project>-DB package, so registered models can
+   be referenced the same way db/seeds.lisp does, e.g.:
 
-   @condition error Not yet implemented
+     (save (make-record '<project>/models/user:<user> :name \"a\"))
+
+   Type (quit), (exit), :quit, :exit, or send EOF (Ctrl-D) to leave the
+   console; the DB connection pool is shut down on the way out either way.
+
+   @return [t] Always returns t once the console session ends
    "
-  (error "Not yet implemented"))
+  (startup-connection-pool)
+  (initialize-table-information)
+  (unwind-protect
+      (let ((*package* (console-repl-package))
+            (eof-marker (list :eof))
+            (skip-marker (list :skip)))
+        (format t "~&clails console (project: ~A, package: ~A)~%"
+                *project-name* (package-name *package*))
+        (format t "Type (quit), (exit), or Ctrl-D to leave the console.~%~%")
+        (loop
+          (format t "~&~A> " (package-name *package*))
+          (force-output)
+          (let ((form (handler-case (read *standard-input* nil eof-marker)
+                        (end-of-file () eof-marker)
+                        (reader-error (e)
+                          (format t "~&; Read error: ~A~%" e)
+                          (ignore-errors (read-line *standard-input* nil ""))
+                          skip-marker))))
+            (cond
+              ((eq form eof-marker)
+               (format t "~%")
+               (return t))
+              ((eq form skip-marker)
+               nil)
+              ((console-quit-form-p form)
+               (return t))
+              (t
+               (handler-case
+                   (let ((results (multiple-value-list (eval form))))
+                     (setf *** ** ** * * (first results))
+                     (if results
+                         (dolist (r results)
+                           (format t "~&~S~%" r))
+                         (format t "~&; No value~%")))
+                 (error (e)
+                   (format t "~&; Error: ~A~%" e))))))))
+    (shutdown-connection-pool)))
 
 (defparameter +clack-handler-prefix+ "clack-handler-"
   "Prefix shared by every Clack handler backend's ASDF system name.")


### PR DESCRIPTION
Closes #164

## Summary

- Implements `clails console` (previously an unimplemented stub in `src/cmd.lisp` that just signaled an error) as an interactive REPL, analogous to `rails console`.
- Reuses the existing `load-project` initialization path (the same one `server`/`db:*`/`test` use) — `roswell/clails.ros`'s new `console` command calls `(load-project)` and `(load-db-package)` before invoking `clails/cmd:console`, exactly like the `db:*` commands do.
- `clails/cmd:console` starts the DB connection pool, loads table metadata, then hands control to a small read-eval-print loop that reads/evals/prints forms from stdin, running in the project's `<project>-DB` package (the same package `db/seeds.lisp` and migration files execute in — it already `:use`s `clails/model` and imports every registered model package), so a user can reference models the same way seeds do.
- Typing `(quit)`, `(exit)`, `:quit`, `:exit`, or sending EOF (Ctrl-D) ends the session; the connection pool is always shut down on the way out via `unwind-protect`. The quit/exit check matches by symbol name (not identity), so it works regardless of which package `*package*` happens to be bound to.
- Standard REPL history variables `*`, `**`, `***` are supported.
- Added `### clails console` documentation sections to `document/command.md` and `document/command_ja.md`, matching the existing style used for `server`/`stop`/etc.

Per the issue, sibling issue #161 (splitting `src/cmd.lisp` into per-subcommand files) is explicitly out of scope for this change — `cmd.lisp` remains a single file, and `console` was added alongside the existing stub following the file's existing conventions (docstrings with `@param`/`@return`, etc).

## Test plan

- [x] Verified `src/cmd.lisp` compiles/loads cleanly (no reader or compile errors) and that `console`, `console-quit-form-p`, and `console-repl-package` are defined, using a standalone SBCL/ASDF load of this worktree's sources.
- [x] Verified the quit/exit detection logic (`console-quit-form-p`) against `(quit)`, `(exit)`, `:quit`, `:exit`, bare `quit`/`exit`, and a normal form like `(+ 1 2)`, in a throwaway package that does not inherit those symbols — confirms it isn't fooled by symbol identity/package differences.
- [x] Ran a real interactive smoke test inside the project's docker test image: `ros install roswell/clails.ros`, `clails new demoapp -d sqlite3`, `clails generate:model user`, wrote a migration with a real `create-table`, ran `clails db:migrate`, then piped multiple Lisp forms into `clails console` over stdin:
  - `(save (make-record 'demoapp/models/user:<user> :name "alice" :email "alice@example.com"))` → printed the saved `<USER>` instance with a real DB-assigned id/timestamps.
  - `(mapcar (lambda (u) (ref u :name)) (execute-query (query demoapp/models/user:<user> :as :user) nil))` → returned `("alice")`, reading the row back from the DB.
  - `(quit)` cleanly ended the console session.
  This confirms genuine interactivity (multiple sequential forms read and evaluated, real results printed, real DB reads/writes through the loaded model) and not just "doesn't crash."
- [x] `make test` — all 66 tests pass.
- [x] `make e2e.test` — todo-app E2E suite passes (unrelated to this change, confirms no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)