### PR TITLE
Document CLI command initialization stages; clear error for unstarted connection pool

### DIFF
--- a/document/environment.md
+++ b/document/environment.md
@@ -7,6 +7,10 @@ This guide explains environment variables and global variables available to appl
 
 ## Table of Contents
 
+- [Initialization Stages](#initialization-stages)
+  - The three stages
+  - Which stage each CLI command reaches
+  - Practical implication
 1. [Environment Variables](#1-environment-variables)
    - Database-related
    - Environment Variable Utility Functions
@@ -24,6 +28,56 @@ This guide explains environment variables and global variables available to appl
 5. [Configuration File Examples](#5-configuration-file-examples)
 6. [Best Practices](#6-best-practices)
 7. [Troubleshooting](#7-troubleshooting)
+
+---
+
+## Initialization Stages
+
+Before application code relies on a value in `clails/environment`, it helps to know *when* that value actually becomes populated. clails initializes state in three stages, and which stages a given `clails` CLI command reaches depends on the command. This is why code that assumes a later-stage variable is available -- most notably `*connection-pool*` -- can work fine under `clails server` but fail unexpectedly under `clails db:seed`, `clails task ...`, or other commands.
+
+### The three stages
+
+**Stage 1 -- File-load time**
+
+Reached simply by loading the `clails` system itself; every invocation of the `clails` CLI (including `--help`) loads `clails`. At this point only the framework's built-in defaults from `src/environment.lisp` are in effect: `*project-environment*` defaults to `:develop`, `*connection-pool*` is `nil`, `*routing-tables*` holds the single built-in default route, `*startup-hooks*`/`*shutdown-hooks*` hold only the framework's own defaults, and so on. No project has been loaded yet.
+
+**Stage 2 -- `clails.boot` execution ("project load") time**
+
+Reached by every command except `new` (and running `clails` with no command / `--help`). Triggered by `roswell/clails.ros`'s `load-project`, which loads the project's `clails.boot`. In order, this:
+
+1. Runs `(ql:quickload :<project>)`, which walks the ASDF package-inferred-system dependency graph rooted at `app/application-loader.lisp` and runs every file's top-level forms. This is where project config files run: `app/config/environment.lisp` sets `*project-name*` and `*routing-tables*`, and pushes onto `*startup-hooks*`/`*shutdown-hooks*`; `app/config/database.lisp` sets `*database-type*`; `app/models/package.lisp` registers models.
+2. Sets `*project-dir*`, `*migration-base-dir*`, and `*task-base-dir*` explicitly.
+3. Applies `CLAILS_ENV` (via `set-environment`), setting `*project-environment*`.
+4. Calls `<project>/config/database:initialize-database-config`, which sets `*database-config*`.
+
+After Stage 2, every `clails/environment` variable is populated **except** the ones the connection pool is responsible for: `*connection-pool*`, the internal `*thread-connection-pool*`, and anything a startup hook would otherwise set up (e.g. `*table-information-initialized*`, unless something calls `initialize-table-information` directly).
+
+**Stage 3 -- runtime startup (`call-startup-hooks`)**
+
+This is where `*connection-pool*` gets created, by running every function in `*startup-hooks*` in order (default: `clails/model/connection:startup-connection-pool`; generated projects also push `initialize-table-information` and a logger initializer onto the front of this list in `app/config/environment.lisp`). **Only `clails server` reaches this stage** -- `call-startup-hooks` is called once, right before the server starts accepting requests, from `clails/cmd:server` (`src/cmd.lisp`). There is a corresponding shutdown stage (`call-shutdown-hooks`, running `*shutdown-hooks*`), reached only by `clails stop` / when the running server is interrupted.
+
+> **`db:seed` and `test` are a special case.** Neither calls `call-startup-hooks`, but both call `clails/model/connection:startup-connection-pool` (and `initialize-table-information`) directly -- hard-coded in `src/cmd.lisp` -- before doing their real work, and shut the pool back down (`shutdown-connection-pool`) afterward. So `*connection-pool*` **is** populated while `db:seed`/`test` run, but any *additional* custom startup hooks a project has added to `*startup-hooks*` (beyond the default connection-pool startup) do **not** run for these two commands, since they bypass `call-startup-hooks` entirely.
+>
+> `db:create`, `db:migrate`, `db:migrate:up`, `db:migrate:down`, and `db:rollback` don't need the pool at all -- they talk to the database through short-lived direct connections (`with-db-connection-direct`), never through `*connection-pool*`.
+
+### Which stage each CLI command reaches
+
+| Command | Reaches Stage 2 (project loaded)? | Reaches Stage 3 (`*connection-pool*` populated)? | Notes |
+|---|---|---|---|
+| `new` | No | No | Creates a project on disk; there is no project to load yet. |
+| `environment` | Yes | No | Just prints `*project-environment*`. |
+| `generate:model` / `:migration` / `:view` / `:controller` / `:scaffold` / `:task` | Yes | No | File generation only; these never touch the database. |
+| `db:create` | Yes | No (direct connection) | Uses `with-db-connection-direct`, not the pool. |
+| `db:migrate`, `db:migrate:up`, `db:migrate:down`, `db:rollback`, `db:status` | Yes | No (direct connection) | Migrations run over direct connections, not the pool. |
+| `db:seed` | Yes | **Yes**, via a direct call to `startup-connection-pool` / `initialize-table-information` (not `call-startup-hooks`) | Custom startup hooks beyond the default pool startup are skipped. Pool is shut down again once seeding finishes. |
+| `test` | Yes (environment forced to `:test`) | **Yes**, same direct-call caveat as `db:seed` | Pool is shut down again after the test run. |
+| `task` (custom tasks via `clails task ...`) | Yes | No, unless the task itself calls `startup-connection-pool` | The framework does not start the pool for tasks; a task that needs pooled DB access must start (and ideally shut down) the pool itself. |
+| `server` | Yes | **Yes**, via `call-startup-hooks` | The only command that runs the full, user-configurable `*startup-hooks*` list. |
+| `stop` | Yes | N/A | Only meaningful within the same running server process; a standalone invocation has nothing running to stop. |
+
+### Practical implication
+
+Code that reads `clails/environment:*connection-pool*` -- directly, or indirectly via `clails/model/connection:get-connection` / `with-db-connection` -- must not assume it has been populated just because the project has loaded (Stage 2). It is guaranteed only under `server`, `db:seed`, and `test`. If you write a custom task, migration helper, or other code path that needs a pooled database connection, call `clails/model/connection:startup-connection-pool` yourself first (and `shutdown-connection-pool` when done), or use a direct connection (`with-db-connection-direct`) instead. `clails/model/connection:get-connection` raises a clear error naming the missing initialization step instead of failing with an obscure error from inside the connection-pool library when `*connection-pool*` is `nil`.
 
 ---
 

--- a/document/environment_ja.md
+++ b/document/environment_ja.md
@@ -7,6 +7,10 @@ clails アプリケーションは、環境変数を通じて動作をカスタ�
 
 ## 目次
 
+- [初期化ステージ](#初期化ステージ)
+  - 3つのステージ
+  - CLIコマンドごとに到達するステージ
+  - 実務上の意味
 1. [環境変数](#1-環境変数)
    - データベース関連
    - 環境変数の取得ユーティリティ
@@ -25,6 +29,56 @@ clails アプリケーションは、環境変数を通じて動作をカスタ�
 5. [設定ファイルの例](#5-設定ファイルの例)
 6. [ベストプラクティス](#6-ベストプラクティス)
 7. [トラブルシューティング](#7-トラブルシューティング)
+
+---
+
+## 初期化ステージ
+
+アプリケーションコードが `clails/environment` の値に依存する前に、その値が実際に「いつ」設定されるのかを把握しておく必要があります。clails は3つのステージで状態を初期化しますが、どのステージまで到達するかは実行する `clails` CLI コマンドによって異なります。これが原因で、より後のステージで設定される変数（特に `*connection-pool*`）が既に利用可能だと仮定したコードが、`clails server` では問題なく動いても `clails db:seed` やその他のコマンドでは予期せず失敗することがあります。
+
+### 3つのステージ
+
+**ステージ1 -- ファイルロード時**
+
+`clails` システム自体がロードされた時点で到達します。`--help` を含め、`clails` CLI のすべての呼び出しはこの時点に到達します。この段階では `src/environment.lisp` に定義されたフレームワークの組み込みデフォルト値のみが有効です。例えば `*project-environment*` は `:develop`、`*connection-pool*` は `nil`、`*routing-tables*` は組み込みのデフォルトルート1件のみ、`*startup-hooks*`/`*shutdown-hooks*` もフレームワーク自身のデフォルトのみです。この時点ではまだプロジェクトはロードされていません。
+
+**ステージ2 -- `clails.boot` 実行（プロジェクトロード）時**
+
+`new` コマンド（およびコマンドなし/`--help` での実行）以外のすべてのコマンドで到達します。`roswell/clails.ros` の `load-project` がプロジェクトの `clails.boot` をロードすることで発生します。順を追うと以下のようになります。
+
+1. `(ql:quickload :<project>)` を実行します。これは `app/application-loader.lisp` を起点とする ASDF package-inferred-system の依存グラフをたどり、各ファイルのトップレベルフォームを実行します。プロジェクトの設定ファイルが実行されるのはこの時点です。`app/config/environment.lisp` が `*project-name*` と `*routing-tables*` を設定し、`*startup-hooks*`/`*shutdown-hooks*` に要素を push します。`app/config/database.lisp` が `*database-type*` を設定します。`app/models/package.lisp` がモデルを登録します。
+2. `*project-dir*`、`*migration-base-dir*`、`*task-base-dir*` を明示的に設定します。
+3. `CLAILS_ENV`（`set-environment` 経由）を適用し、`*project-environment*` を設定します。
+4. `<project>/config/database:initialize-database-config` を呼び出し、`*database-config*` を設定します。
+
+ステージ2が終わった時点で、コネクションプールが担当する変数（`*connection-pool*`、内部の `*thread-connection-pool*`、および `initialize-table-information` を直接呼ばない限り設定されない `*table-information-initialized*` など）を**除く**すべての `clails/environment` 変数が設定済みになります。
+
+**ステージ3 -- ランタイム起動（`call-startup-hooks`）**
+
+`*connection-pool*` が実際に作られるのはこの段階です。`*startup-hooks*` に登録された関数を順に実行します（デフォルトは `clails/model/connection:startup-connection-pool` のみ。生成されたプロジェクトでは `app/config/environment.lisp` でこのリストの先頭に `initialize-table-information` とロガー初期化処理も push されます）。**このステージに到達するのは `clails server` のみ**です。`call-startup-hooks` はサーバーがリクエストの受付を開始する直前に、`clails/cmd:server`（`src/cmd.lisp`）から一度だけ呼び出されます。対応するシャットダウンステージ（`*shutdown-hooks*` を実行する `call-shutdown-hooks`）は `clails stop` 実行時、あるいは稼働中のサーバーが割り込まれたときにのみ到達します。
+
+> **`db:seed` と `test` は特殊なケースです。** どちらも `call-startup-hooks` は呼びませんが、実際の処理を行う前に `clails/model/connection:startup-connection-pool`（および `initialize-table-information`）を `src/cmd.lisp` 内で直接（ハードコードされた形で）呼び出し、処理後にプールをシャットダウン（`shutdown-connection-pool`）します。そのため `db:seed`/`test` の実行中は `*connection-pool*` が**設定されています**が、プロジェクトが `*startup-hooks*` に追加したデフォルト以外のカスタムフックは、`call-startup-hooks` を経由しないためこの2つのコマンドでは実行**されません**。
+>
+> `db:create`、`db:migrate`、`db:migrate:up`、`db:migrate:down`、`db:rollback` はそもそもプールを必要としません。これらは短命な直接接続（`with-db-connection-direct`）でデータベースとやり取りしており、`*connection-pool*` は一切使いません。
+
+### CLIコマンドごとに到達するステージ
+
+| コマンド | ステージ2（プロジェクトロード）に到達するか | ステージ3（`*connection-pool*` 設定済み）に到達するか | 備考 |
+|---|---|---|---|
+| `new` | しない | しない | ディスク上にプロジェクトを作成するだけで、まだロードするプロジェクトが存在しない |
+| `environment` | する | しない | `*project-environment*` を表示するだけ |
+| `generate:model` / `:migration` / `:view` / `:controller` / `:scaffold` / `:task` | する | しない | ファイル生成のみで、データベースには一切触れない |
+| `db:create` | する | しない（直接接続） | `with-db-connection-direct` を使用し、プールは使わない |
+| `db:migrate`、`db:migrate:up`、`db:migrate:down`、`db:rollback`、`db:status` | する | しない（直接接続） | マイグレーションはプールではなく直接接続で実行される |
+| `db:seed` | する | **する**（`call-startup-hooks` ではなく `startup-connection-pool`/`initialize-table-information` の直接呼び出し経由） | デフォルトのプール起動以外のカスタム起動フックはスキップされる。シード完了後にプールは再びシャットダウンされる |
+| `test` | する（環境は強制的に `:test` になる） | **する**（`db:seed` と同様の直接呼び出しの注意点あり） | テスト実行後にプールは再びシャットダウンされる |
+| `task`（`clails task ...` によるカスタムタスク） | する | しない（タスク自身が `startup-connection-pool` を呼ばない限り） | フレームワークはタスクのためにプールを起動しない。プール経由のDBアクセスが必要なタスクは自分でプールを起動する必要がある |
+| `server` | する | **する**（`call-startup-hooks` 経由） | ユーザーが設定可能な `*startup-hooks*` リスト全体を実行する唯一のコマンド |
+| `stop` | する | 該当なし | 同一プロセス内で稼働中のサーバーに対してのみ意味を持つ。単独で実行しても停止対象は存在しない |
+
+### 実務上の意味
+
+`clails/environment:*connection-pool*` を読むコード（直接、あるいは `clails/model/connection:get-connection`/`with-db-connection` 経由での間接的な参照を含む）は、プロジェクトがロードされている（ステージ2に到達している）というだけでプールが設定済みだと仮定してはいけません。これが保証されるのは `server`、`db:seed`、`test` の実行中だけです。プール経由のデータベース接続が必要なカスタムタスクやその他のコード経路を書く場合は、自分で `clails/model/connection:startup-connection-pool` を呼び出す（処理後に `shutdown-connection-pool` も呼ぶ）か、代わりに直接接続（`with-db-connection-direct`）を使ってください。`*connection-pool*` が `nil` の場合、`clails/model/connection:get-connection` はコネクションプールライブラリ内部から発生する分かりにくいエラーの代わりに、何が初期化されていないかを明示したエラーを送出します。
 
 ---
 

--- a/src/model/connection.lisp
+++ b/src/model/connection.lisp
@@ -160,12 +160,23 @@
 
 (defun get-connection ()
   "Get database connection for the current thread.
-   
+
    If a connection is already associated with the thread, returns it.
    Otherwise, acquires a new connection from the pool and associates it with the thread.
-   
+
    @return [dbi-cp.proxy::<dbi-connection-proxy>] Database connection
+   @condition error Signaled with a clear message when *connection-pool* has not
+     been initialized yet (e.g. this is called from a CLI command that never
+     reaches the runtime-startup stage that creates the pool -- see
+     document/environment.md's \"Initialization Stages\" section).
    "
+  (when (null *connection-pool*)
+    (error "Database connection pool is not initialized (clails/environment:*connection-pool* is NIL). ~
+This code path requires the connection pool to have been started via ~
+clails/model/connection:startup-connection-pool (this happens automatically for the `server` command's ~
+runtime-startup stage, and is called directly by `db:seed` and `test`). If you are calling this from a ~
+different command or a custom task, call startup-connection-pool yourself before using the database. ~
+See document/environment.md's \"Initialization Stages\" section for details."))
   (let ((current-th (bt:current-thread)))
     (get-connection-by-thread current-th)))
 


### PR DESCRIPTION
Closes #157

## Summary

- clails/environment variables become meaningful at one of three points: framework file-load time, `clails.boot`'s project-load time (`load-project`, quickloading the project's ASDF system, then setting `*project-dir*`/etc. and applying `CLAILS_ENV`), or the `server` command's runtime-startup (`call-startup-hooks`, which is what actually creates `*connection-pool*`). Which stage a given CLI command reaches was previously undocumented, so code that assumed a stage-3 resource (most notably `*connection-pool*`) was already available could fail unexpectedly under a command that never reaches that stage.
- Traced the actual code path per command in `roswell/clails.ros` and `src/cmd.lisp` and added an "Initialization Stages" section to `document/environment.md` and `document/environment_ja.md`, with a table of which stage each CLI command reaches. Notably, `db:seed` and `test` call `startup-connection-pool`/`initialize-table-information` directly (bypassing `call-startup-hooks`), so `*connection-pool*` is populated for them too, but any additional custom startup hooks a project registers are skipped for these two commands. `db:create`/`db:migrate*`/`db:rollback`/`db:status` never touch the pool at all -- they use short-lived direct connections.
- Small defensive/diagnostic addition: `clails/model/connection:get-connection` now raises a clear error naming the missing initialization step when `*connection-pool*` is `nil`, instead of failing later with an obscure error from inside the connection-pool library. This only changes behavior on the already-broken nil-pool path -- no change when the pool is populated.
- Did not touch the initialization sequence itself or `cmd.lisp`'s structure, per the scope for this issue (that's covered by other issues in the same milestone, e.g. #158, #161).

## Test plan

- [x] `ros run --eval '(ql:quickload :clails)'` locally -- confirms `src/model/connection.lisp` still compiles/loads cleanly.
- [x] Full unit test suite (`clails-test.asd` via `rove`, MySQL + PostgreSQL + SQLite3 backends) run against isolated, uniquely-named Docker Compose containers (to avoid clobbering other concurrently running agents' shared `clails_test_mysql`/`clails_test_postgresql` containers): all 66 tests passed.
- [x] `make e2e.test`-equivalent (todo-app E2E script) run against an isolated container: exercises `db:create`, `db:migrate`, `db:seed`, `server`, and `test`, all of which touch the `get-connection`/connection-pool path this PR modifies -- completed successfully with all sub-suites passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)