### PR TITLE
Rename internal-only control variables with a % prefix

### DIFF
--- a/document/environment.md
+++ b/document/environment.md
@@ -973,6 +973,24 @@ qlot exec rove myapp-test.asd
 2. **Environment-independent Configuration**: Write directly in configuration files
 3. **Complex Configuration**: Create dedicated initialization functions
 
+### Internal-only Control Variables
+
+A small number of special variables in `clails/environment` (for example
+`*%sqlite3-transaction-mode*`, `*%sqlite3-lock-module-loaded*`,
+`*%table-information-initialized*`, and `*%query-initialization-callbacks*`)
+exist purely as internal control/bookkeeping state for clails itself — they
+are rebound or mutated by macros and internal functions (such as
+`with-locked-transaction`) and are **not** meant to be read or set from
+application code.
+
+These variables are named with a leading `%` (e.g. `*%sqlite3-transaction-mode*`)
+to visibly distinguish them from ordinary, user-facing configuration variables
+like `*routing-tables*` or `*sqlite3-busy-timeout*`, even though both kinds
+are technically exported from the same package. If you are contributing to
+clails itself and need to introduce a new internal-only control variable,
+please follow this same `%`-prefix convention so the distinction stays clear
+for future readers.
+
 ---
 
 ## 7. Troubleshooting

--- a/document/environment_ja.md
+++ b/document/environment_ja.md
@@ -1063,6 +1063,21 @@ qlot exec rove myapp-test.asd
 2. **環境に依存しない設定**: 設定ファイルに直接記述
 3. **複雑な設定**: 専用の初期化関数を作成
 
+### 内部専用の制御変数
+
+`clails/environment` パッケージには、`*%sqlite3-transaction-mode*` や
+`*%sqlite3-lock-module-loaded*`、`*%table-information-initialized*`、
+`*%query-initialization-callbacks*` のように、clails 自身が内部的に使用する
+制御・管理用の特殊変数がいくつか存在します。これらは `with-locked-transaction`
+などのマクロや内部関数によって再束縛・変更されるものであり、アプリケーション
+コードから直接参照したり設定したりすることを意図していません。
+
+これらの変数名には先頭に `%` を付けることで、`*routing-tables*` や
+`*sqlite3-busy-timeout*` のような通常のユーザー向け設定変数と、技術的には
+同じパッケージからエクスポートされていても明確に区別できるようにしています。
+clails 自体にコントリビュートする際、新たに内部専用の制御変数を追加する
+場合は、今後もこの `%` プレフィックスの命名規則に従ってください。
+
 ---
 
 ## 7. トラブルシューティング

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -15,10 +15,10 @@
            #:*default-lock-mode*
            #:*sqlite3-busy-timeout*
            #:*sqlite3-lock-retry-count*
-           #:*sqlite3-transaction-mode*
-           #:*sqlite3-lock-module-loaded*
-           #:*table-information-initialized*
-           #:*query-initialization-callbacks*
+           #:*%sqlite3-transaction-mode*
+           #:*%sqlite3-lock-module-loaded*
+           #:*%table-information-initialized*
+           #:*%query-initialization-callbacks*
            #:<database-type>
            #:<database-type-mysql>
            #:<database-type-postgresql>
@@ -180,7 +180,7 @@
 
    This can be overridden in <project>/app/config/environment.lisp")
 
-(defvar *sqlite3-transaction-mode* nil
+(defvar *%sqlite3-transaction-mode* nil
   "SQLite3 transaction mode for the current dynamic context.
 
    This is a special variable used to pass the transaction mode
@@ -192,29 +192,45 @@
    - :exclusive   - Exclusive lock (BEGIN EXCLUSIVE)
 
    This variable is set by with-locked-transaction macro and should not
-   be set directly by user code.")
+   be set directly by user code.
 
-(defvar *sqlite3-lock-module-loaded* nil
+   NOTE: The leading % in the name marks this as an internal-only control
+   variable (per clails' naming convention for such variables). Do not read
+   or set it from application code.")
+
+(defvar *%sqlite3-lock-module-loaded* nil
   "Flag indicating whether sqlite3-lock module has been loaded.
 
    Set to T after src/model/impl/sqlite3-lock.lisp is successfully loaded.
-   Used to ensure the module is loaded only once.")
+   Used to ensure the module is loaded only once.
 
-(defvar *table-information-initialized* nil
+   NOTE: The leading % in the name marks this as an internal-only control
+   variable (per clails' naming convention for such variables). Do not read
+   or set it from application code.")
+
+(defvar *%table-information-initialized* nil
   "Flag indicating whether initialize-table-information has been executed.
 
    Set to T after initialize-table-information completes successfully.
    Used by query macro to determine whether to create actual query instances
-   or placeholder instances for lazy initialization.")
+   or placeholder instances for lazy initialization.
 
-(defvar *query-initialization-callbacks* nil
+   NOTE: The leading % in the name marks this as an internal-only control
+   variable (per clails' naming convention for such variables). Do not read
+   or set it from application code.")
+
+(defvar *%query-initialization-callbacks* nil
   "List of callback functions to initialize query placeholders.
 
    When query macro is expanded before initialize-table-information is called,
    callback functions are registered here to initialize query placeholders later.
    Each callback takes no arguments and sets the actual query instance to the
    corresponding placeholder's actual-query slot.
-   Cleared after initialize-table-information executes all callbacks.")
+   Cleared after initialize-table-information executes all callbacks.
+
+   NOTE: The leading % in the name marks this as an internal-only control
+   variable (per clails' naming convention for such variables). Do not read
+   or set it from application code.")
 
 (defparameter +ENVIRONMENT-NAMES+ '("DEVELOP" "TEST" "PRODUCTION")
   "List of valid environment names.")

--- a/src/model/base-model.lisp
+++ b/src/model/base-model.lisp
@@ -3,8 +3,8 @@
   (:use #:cl)
   (:import-from #:clails/environment
                 #:*database-type*
-                #:*table-information-initialized*
-                #:*query-initialization-callbacks*)
+                #:*%table-information-initialized*
+                #:*%query-initialization-callbacks*)
   (:import-from #:clails/model/connection
                 #:with-db-connection-direct)
   (:import-from #:clails/util
@@ -390,14 +390,14 @@ Example: ((:name :id
                (format t "done~%"))))
 
   ;; Mark table information as initialized
-  (setf *table-information-initialized* t)
+  (setf *%table-information-initialized* t)
 
   ;; Execute all query initialization callbacks
-  (dolist (callback *query-initialization-callbacks*)
+  (dolist (callback *%query-initialization-callbacks*)
     (funcall callback))
 
   ;; Clear callbacks list
-  (setf *query-initialization-callbacks* nil))
+  (setf *%query-initialization-callbacks* nil))
 
 (defun debug-table-information ()
   "Display all table metadata for debugging purposes.

--- a/src/model/connection.lisp
+++ b/src/model/connection.lisp
@@ -4,7 +4,7 @@
   (:import-from #:clails/environment
                 #:*database-type*
                 #:*connection-pool*
-                #:*sqlite3-lock-module-loaded*)
+                #:*%sqlite3-lock-module-loaded*)
   (:export #:startup-connection-pool
            #:shutdown-connection-pool
            #:create-connection-pool-impl
@@ -91,10 +91,10 @@
 
     ;; Load SQLite3 lock module if using SQLite3
     (when (and (typep *database-type* 'clails/environment:<database-type-sqlite3>)
-               (not clails/environment:*sqlite3-lock-module-loaded*))
+               (not clails/environment:*%sqlite3-lock-module-loaded*))
       (load (merge-pathnames "src/model/impl/sqlite3-lock.lisp"
                              (asdf:system-source-directory :clails)))
-      (setf clails/environment:*sqlite3-lock-module-loaded* t))))
+      (setf clails/environment:*%sqlite3-lock-module-loaded* t))))
 
 (defun shutdown-connection-pool ()
   "Shutdown the database connection pool.

--- a/src/model/impl/sqlite3-lock.lisp
+++ b/src/model/impl/sqlite3-lock.lisp
@@ -2,7 +2,7 @@
 (defpackage #:clails/model/impl/sqlite3-lock
   (:use #:cl)
   (:import-from #:clails/environment
-                #:*sqlite3-transaction-mode*)
+                #:*%sqlite3-transaction-mode*)
   (:import-from #:clails/logger
                 #:log-level-enabled-p
                 #:log.sql)
@@ -17,7 +17,7 @@
 (defmethod dbi:begin-transaction ((conn dbd.sqlite3:dbd-sqlite3-connection))
   "Override begin-transaction for SQLite3 to support lock modes.
    
-   Checks *sqlite3-transaction-mode* to determine which BEGIN statement to use.
+   Checks *%sqlite3-transaction-mode* to determine which BEGIN statement to use.
    This allows with-locked-transaction to control the transaction lock level
    while maintaining compatibility with regular with-transaction usage.
 
@@ -28,7 +28,7 @@
 
    @param conn [dbd-sqlite3-connection] SQLite3 database connection
    "
-  (let* ((tx-mode clails/environment:*sqlite3-transaction-mode*)
+  (let* ((tx-mode clails/environment:*%sqlite3-transaction-mode*)
          (begin-sql (case tx-mode
                       (:immediate "BEGIN IMMEDIATE")
                       (:exclusive "BEGIN EXCLUSIVE")

--- a/src/model/lock.lisp
+++ b/src/model/lock.lisp
@@ -6,8 +6,8 @@
                 #:*database-type*
                 #:*sqlite3-busy-timeout*
                 #:*sqlite3-lock-retry-count*
-                #:*sqlite3-transaction-mode*
-                #:*sqlite3-lock-module-loaded*)
+                #:*%sqlite3-transaction-mode*
+                #:*%sqlite3-lock-module-loaded*)
   (:import-from #:clails/model/query
                 #:execute-query)
   (:import-from #:clails/model/connection
@@ -32,7 +32,7 @@
    then executes the body. The transaction is automatically committed on success
    or rolled back on error.
 
-   For SQLite3, sets *sqlite3-transaction-mode* to control BEGIN statement type,
+   For SQLite3, sets *%sqlite3-transaction-mode* to control BEGIN statement type,
    and implements retry logic on lock errors with exponential backoff.
 
    @param variable-name [symbol] Variable to bind the retrieved record(s)
@@ -78,7 +78,7 @@
        (retry-on-lock-error *database-type*
          (lambda ()
            ;; Set transaction mode for SQLite3
-           (let ((clails/environment:*sqlite3-transaction-mode* ,mode-var))
+           (let ((clails/environment:*%sqlite3-transaction-mode* ,mode-var))
              (dbi-cp:with-transaction ,connection-var
                ;; Evaluate query and add lock clause
                (let* ((,query-var ,query-spec)
@@ -101,12 +101,12 @@
 
    @return [boolean] T if module was loaded, NIL if already loaded
    "
-  (unless clails/environment:*sqlite3-lock-module-loaded*
+  (unless clails/environment:*%sqlite3-lock-module-loaded*
     (when (log-level-enabled-p :info :sql)
       (log.sql "Loading SQLite3 lock module"))
     (load (merge-pathnames "src/model/impl/sqlite3-lock.lisp"
                            (asdf:system-source-directory :clails)))
-    (setf clails/environment:*sqlite3-lock-module-loaded* t)
+    (setf clails/environment:*%sqlite3-lock-module-loaded* t)
     t))
 
 

--- a/src/model/query.lisp
+++ b/src/model/query.lisp
@@ -12,8 +12,8 @@
                 #:optimistic-lock-error)
   (:import-from #:clails/environment
                 #:*database-type*
-                #:*table-information-initialized*
-                #:*query-initialization-callbacks*)
+                #:*%table-information-initialized*
+                #:*%query-initialization-callbacks*)
   (:import-from #:clails/model/base-model
                 #:<base-model>
                 #:validate
@@ -457,7 +457,7 @@
                    :order-by order-by
                    :limit limit
                    :offset offset)))
-    `(if clails/environment:*table-information-initialized*
+    `(if clails/environment:*%table-information-initialized*
          ;; Table information initialized: create actual query instance
          (let ((q (make-instance '<query>
                                  :model ',model
@@ -493,7 +493,7 @@
                                            :offset ',offset)))
                      (setf (slot-value q 'query-source-info) ',(make-source-info))
                      (setf (actual-query placeholder) q)))
-                 clails/environment:*query-initialization-callbacks*)
+                 clails/environment:*%query-initialization-callbacks*)
            placeholder))))
 
 

--- a/test/model/query-lazy-initialization.lisp
+++ b/test/model/query-lazy-initialization.lisp
@@ -18,8 +18,8 @@
   (clrhash clails/model/base-model::*table-information*)
   
   ;; Reset initialization state
-  (setf clails/environment:*table-information-initialized* nil)
-  (setf clails/environment:*query-initialization-callbacks* nil)
+  (setf clails/environment:*%table-information-initialized* nil)
+  (setf clails/environment:*%query-initialization-callbacks* nil)
   
   ;; define models
   (defmodel <blog> (<base-model>)
@@ -46,15 +46,15 @@
   (clails/model/connection:shutdown-connection-pool)
   
   ;; Reset initialization state
-  (setf clails/environment:*table-information-initialized* nil)
-  (setf clails/environment:*query-initialization-callbacks* nil))
+  (setf clails/environment:*%table-information-initialized* nil)
+  (setf clails/environment:*%query-initialization-callbacks* nil))
 
 
 (deftest test-query-before-initialization
   (testing "query macro before initialize-table-information should create placeholder"
     ;; Ensure we're in uninitialized state
-    (setf clails/environment:*table-information-initialized* nil)
-    (setf clails/environment:*query-initialization-callbacks* nil)
+    (setf clails/environment:*%table-information-initialized* nil)
+    (setf clails/environment:*%query-initialization-callbacks* nil)
     
     ;; Create query before initialization
     (let ((q (query <blog>
@@ -66,7 +66,7 @@
       (ok (typep q 'clails/model/query::<query-placeholder>))
       
       ;; Callback should be registered
-      (ok (= 1 (length clails/environment:*query-initialization-callbacks*)))
+      (ok (= 1 (length clails/environment:*%query-initialization-callbacks*)))
       
       ;; actual-query should be nil
       (ok (null (slot-value q 'clails/model/query::actual-query)))
@@ -92,14 +92,14 @@
       (ok (typep q 'clails/model/query::<query>))
       
       ;; No new callback should be registered
-      (ok (= 0 (length clails/environment:*query-initialization-callbacks*))))))
+      (ok (= 0 (length clails/environment:*%query-initialization-callbacks*))))))
 
 
 (deftest test-placeholder-initialization
   (testing "placeholder should be initialized after initialize-table-information"
     ;; Reset initialization state
-    (setf clails/environment:*table-information-initialized* nil)
-    (setf clails/environment:*query-initialization-callbacks* nil)
+    (setf clails/environment:*%table-information-initialized* nil)
+    (setf clails/environment:*%query-initialization-callbacks* nil)
     
     ;; Create query before initialization
     (let ((q (query <blog>
@@ -121,14 +121,14 @@
                  'clails/model/query::<query>))
       
       ;; Callbacks should be cleared
-      (ok (= 0 (length clails/environment:*query-initialization-callbacks*))))))
+      (ok (= 0 (length clails/environment:*%query-initialization-callbacks*))))))
 
 
 (deftest test-placeholder-delegation
   (testing "placeholder should delegate method calls to actual query"
     ;; Reset initialization state
-    (setf clails/environment:*table-information-initialized* nil)
-    (setf clails/environment:*query-initialization-callbacks* nil)
+    (setf clails/environment:*%table-information-initialized* nil)
+    (setf clails/environment:*%query-initialization-callbacks* nil)
     
     ;; Create query before initialization
     (let ((q (query <blog>
@@ -159,8 +159,8 @@
 (deftest test-multiple-placeholders
   (testing "multiple query placeholders should all be initialized"
     ;; Reset initialization state
-    (setf clails/environment:*table-information-initialized* nil)
-    (setf clails/environment:*query-initialization-callbacks* nil)
+    (setf clails/environment:*%table-information-initialized* nil)
+    (setf clails/environment:*%query-initialization-callbacks* nil)
     
     ;; Create multiple queries before initialization
     (let ((q1 (query <blog>
@@ -181,7 +181,7 @@
       (ok (typep q3 'clails/model/query::<query-placeholder>))
       
       ;; Three callbacks should be registered
-      (ok (= 3 (length clails/environment:*query-initialization-callbacks*)))
+      (ok (= 3 (length clails/environment:*%query-initialization-callbacks*)))
       
       ;; Initialize
       (clails/model/base-model:initialize-table-information)
@@ -197,4 +197,4 @@
       (ok (typep (slot-value q3 'clails/model/query::actual-query) 'clails/model/query::<query>))
       
       ;; Callbacks should be cleared
-      (ok (= 0 (length clails/environment:*query-initialization-callbacks*))))))
+      (ok (= 0 (length clails/environment:*%query-initialization-callbacks*))))))


### PR DESCRIPTION
Closes #159

## Summary

`*sqlite3-transaction-mode*` was flagged in #159 because its docstring
explicitly says "should not be set directly by user code" and yet it's
exported like any ordinary configuration variable in `clails/environment`
— nothing signals that it's off-limits. Per the scope decision on the
issue, this PR adopts a naming convention (a leading `%`) rather than
moving internal-only variables into a separate package, since a package
split would require package-qualifying/re-importing every internal
reference for comparatively little benefit over a naming signal.

I read all of `src/environment.lisp` and evaluated every `defvar` against
its own docstring to decide "genuinely internal control/bookkeeping state"
vs. "genuinely user-facing configuration meant for `app/config/*.lisp`".

### Renamed (internal-only control variables)

| Old name | New name | Justification |
|---|---|---|
| `*sqlite3-transaction-mode*` | `*%sqlite3-transaction-mode*` | Docstring literally states: "This variable is set by with-locked-transaction macro and should not be set directly by user code." It's a dynamic-scope channel used purely to pass state from the macro expansion into the `begin-transaction` method override in the sqlite3-lock module. |
| `*sqlite3-lock-module-loaded*` | `*%sqlite3-lock-module-loaded*` | A load-once guard flag ("Used to ensure the module is loaded only once"), pure internal bookkeeping with no configuration meaning — there is nothing for a user to usefully read or set here. |
| `*table-information-initialized*` | `*%table-information-initialized*` | A lazy-initialization guard flag consumed by the `query` macro to decide whether to build real or placeholder query instances. Purely internal state machine bookkeeping, not configuration. |
| `*query-initialization-callbacks*` | `*%query-initialization-callbacks*` | A queue of internal callbacks used to patch up placeholder queries once table info becomes available; explicitly described as being populated and cleared by the framework itself, never touched by user code. |

### Deliberately NOT renamed

- `*connection-pool*` — system-managed, but per the issue's explicit
  guidance this is left alone since advanced user/tooling code may
  legitimately want to inspect it (e.g. for diagnostics/metrics).
- `*default-lock-mode*`, `*sqlite3-busy-timeout*`, `*sqlite3-lock-retry-count*`,
  `*routing-tables*`, `*startup-hooks*`, `*shutdown-hooks*`,
  `*project-name*`, `*project-dir*`, `*project-environment*`,
  `*database-config*`, `*database-type*`, `*migration-base-dir*`,
  `*task-base-dir*` — every one of these has a docstring that says (or
  clearly implies) "set/overridden in `app/config/*.lisp`", i.e. they are
  genuine user-facing configuration, not internal control-flow state.

All four renamed variables stay exported from `clails/environment` (the
issue's scope note left un-exporting to my judgment). I checked
`template/project/` and `document/` for direct references to these four
variable names before deciding, and found none — they were already
undocumented internal implementation details, not part of the published
public API surface in `document/environment.md`/`environment_ja.md`. I
chose to keep them exported anyway (rather than un-export), since the
rename itself is the change requested to signal intent, and keeping the
package structure/export list otherwise stable minimizes the risk
surface for this change. I also added a short "Internal-only Control
Variables" note to `document/environment.md` and `environment_ja.md`
documenting the `%`-prefix convention for future contributors who add new
internal-only variables to `clails/environment`.

Every reference site was updated: `src/environment.lisp` (defvar +
export + docstrings), `src/model/lock.lisp` (`with-locked-transaction`
macro expansion, `load-sqlite3-lock-module`, retry logic docstring),
`src/model/impl/sqlite3-lock.lisp` (the `begin-transaction` override
that reads the transaction mode), `src/model/connection.lisp` (the
"load sqlite3 lock module once" check in `startup-connection-pool`),
`src/model/base-model.lisp` and `src/model/query.lisp` (the
lazy-initialization / query-placeholder machinery), and
`test/model/query-lazy-initialization.lisp` (direct test references to
the lazy-init flag/callback list). A final `grep -rn` for all four old
names across `src/`, `test/`, `template/`, and `document/` confirms zero
remaining references.

### Breaking change note (0.1.0 milestone)

This is a **breaking rename** for anyone directly referencing
`clails/environment:*sqlite3-transaction-mode*`,
`*sqlite3-lock-module-loaded*`, `*table-information-initialized*`, or
`*query-initialization-callbacks*` (even though the framework's own
documentation never encouraged doing so for these particular symbols).
Flagging this explicitly for the 0.1.0 milestone changelog.

## Test plan

- [x] `make test` — full suite passes: **All 66 tests passed**
  (includes `clails-test/model/pessimistic-lock/lock-sqlite3`,
  `clails-test/model/query-lazy-initialization`,
  `clails-test/model/transaction/transaction-sqlite3`, and every other
  sqlite3-tagged package in `clails-test.asd`'s dependency list — all
  green, `BEGIN IMMEDIATE`/`BEGIN EXCLUSIVE`/retry-on-lock-error paths
  all exercised and passing).
- [x] `make e2e.test` — the todo-app e2e suite (sqlite3 by default)
  passes: **All 10 tests passed** across its 3 packages.
- [x] `grep -rn` for each old variable name across `src/`, `test/`,
  `template/`, `document/` returns zero hits — no stray references left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
