### PR TITLE
Add a DB-persisted background job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Comprehensive guides for developing with clails:
 - **[Model Guide](document/model.md)** ([日本語](document/model_ja.md)) - Database operations, queries, transactions, and pessimistic locking
 - **[Logging Guide](document/logging.md)** ([日本語](document/logging_ja.md)) - Flexible logging system with hierarchical loggers
 - **[Task Guide](document/task.md)** ([日本語](document/task_ja.md)) - Custom task system with dependency management
+- **[Job Queue Guide](document/job-queue.md)** ([日本語](document/job-queue_ja.md)) - DB-persisted background job queue with retry/backoff
 - **[View Guide](document/view.md)** ([日本語](document/view_ja.md)) - Template engine and rendering (coming soon)
 - **[Controller Guide](document/controller.md)** ([日本語](document/controller_ja.md)) - Request handling and routing (coming soon)
 - **[Environment Guide](document/environment.md)** ([日本語](document/environment_ja.md)) - Configuration management (coming soon)

--- a/clails-test.asd
+++ b/clails-test.asd
@@ -73,6 +73,10 @@
                #:clails-test/task/registry
                #:clails-test/task/runner
                #:clails-test/task/core
+               #:clails-test/job/registry
+               #:clails-test/job/core
+               #:clails-test/job/queue
+               #:clails-test/job/worker
                #:clails-test/project/generate
                #:clails-test/cmd)
   :perform (test-op (o c)

--- a/document/command.md
+++ b/document/command.md
@@ -83,6 +83,7 @@ clails --help
 | `clails generate:controller` | Generate Controller file |
 | `clails generate:scaffold` | Generate Model, View, and Controller together |
 | `clails generate:task` | Generate Task file |
+| `clails generate:job-queue-setup` | Generate the migration for the job queue's `clails_jobs` table |
 
 ### Database
 
@@ -101,6 +102,12 @@ clails --help
 | Command | Description |
 |---------|-------------|
 | `clails task` | Execute custom tasks |
+
+### Job Queue
+
+| Command | Description |
+|---------|-------------|
+| `clails job:work` | Run the background job worker (see [Job Queue Guide](job-queue.md)) |
 
 ### Testing
 
@@ -525,6 +532,31 @@ Example: `app/tasks/maintenance/cleanup.lisp`
                 ))
 ```
 
+### `clails generate:job-queue-setup` - Generate the Job Queue Migration
+
+Generates the migration that creates the `clails_jobs` table used by the
+[background job queue](job-queue.md). This is a one-time setup step, not a
+per-job generator -- run it once per project, then `clails db:migrate`.
+
+#### Syntax
+
+```bash
+clails generate:job-queue-setup
+```
+
+#### Examples
+
+```bash
+clails generate:job-queue-setup
+clails db:migrate
+```
+
+#### Generated File
+
+```
+db/migrate/YYYYMMDDHHMMSS_create-clails-jobs-table.lisp
+```
+
 ### `clails generate:scaffold` - Generate Scaffold
 
 Generates Model, View, Controller, and Migration files together.
@@ -768,7 +800,40 @@ clails task maintenance:cleanup
 
 ---
 
-## 5. Testing Commands
+## 5. Job Queue Commands
+
+### `clails job:work` - Run the Background Job Worker
+
+Polls the `clails_jobs` table (see [`clails generate:job-queue-setup`](#clails-generatejob-queue-setup---generate-the-job-queue-migration)
+and the [Job Queue Guide](job-queue.md)) and executes due jobs, retrying
+failures with exponential backoff up to each job's `max-attempts`. Blocks
+until interrupted (Ctrl-C).
+
+#### Syntax
+
+```bash
+clails job:work [OPTIONS]
+```
+
+#### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--poll-interval SECONDS` | None | Seconds to sleep between polls that found no due job (default: 1) |
+
+#### Examples
+
+```bash
+# Run the worker (default poll interval)
+clails job:work
+
+# Poll less aggressively
+clails job:work --poll-interval 5
+```
+
+---
+
+## 6. Testing Commands
 
 ### `clails test` - Run Tests
 
@@ -818,7 +883,7 @@ clails test todoapp/models/user
 
 ---
 
-## 6. Common Usage Patterns
+## 7. Common Usage Patterns
 
 ### Starting a New Project
 
@@ -917,7 +982,7 @@ clails test --tag model --exclude slow
 
 ---
 
-## 7. Command Options
+## 8. Command Options
 
 ### Common Options
 
@@ -940,7 +1005,7 @@ clails generate:model user --no-overwrite
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 ### Command Not Found
 
@@ -994,7 +1059,7 @@ clails server -p 8080
 
 ---
 
-## 9. Advanced Usage
+## 10. Advanced Usage
 
 ### Startup and Shutdown Hooks
 

--- a/document/job-queue.md
+++ b/document/job-queue.md
@@ -1,0 +1,333 @@
+# clails Job Queue Guide
+
+## Overview
+
+This guide explains clails' background job queue.
+
+Where the [task system](task.md) (`deftask`/`clails task`) runs a rake-style
+command once, synchronously, from the CLI, the job queue lets application
+code enqueue work to be picked up and executed later, off the request path,
+by a worker process -- the kind of thing you'd reach for Sidekiq or
+ActiveJob for in other frameworks. Jobs are persisted to a plain database
+table (no external broker required), survive a worker restart, and are
+retried automatically with exponential backoff if their handler signals an
+error.
+
+## Basic Concepts
+
+- Job handlers are defined with the `defjob` macro (the async sibling of `deftask`)
+- `enqueue-job` persists a job to the `clails_jobs` table so it can run later
+- A worker (`clails/job:run-worker-loop`, or `clails job:work` from the CLI)
+  polls that table and runs due jobs
+- A failing job is retried with exponential backoff until it either succeeds
+  or exhausts its `:max-attempts`, at which point it is marked `:failed` with
+  the error recorded
+- The `clails_jobs` table is created by a normal migration -- there is
+  nothing job-queue-specific about `db:migrate`/`db:rollback`
+
+## Scope
+
+This is a deliberately small, single-process job queue:
+
+- **In scope**: persisting a job, a worker that claims and runs due jobs,
+  retry with exponential backoff up to a configurable max-attempts, running
+  a job at or after a given time (`:run-at`).
+- **Out of scope** (for now): an external broker (Redis/Sidekiq-style) --
+  the queue is entirely DB-persisted; a web dashboard for inspecting jobs;
+  cron-style recurring schedules (a job runs once, at or after `:run-at`).
+  See [Future Directions](#8-future-directions).
+
+---
+
+## 1. Setting Up the `clails_jobs` Table
+
+The job queue needs a table to persist jobs in. Generate its migration once,
+the same way you would generate any other migration, then run it:
+
+```bash
+clails generate:job-queue-setup
+clails db:migrate
+```
+
+`generate:job-queue-setup` drops a normal migration file into
+`db/migrate/`, pre-filled with the `clails_jobs` table definition (see
+`template/generate/job-queue-migration.lisp.tmpl`) -- there is no separate
+migration mechanism to learn. It creates:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | integer | primary key (added automatically, like every clails table) |
+| `job_name` | string | name the job was registered with via `defjob` |
+| `arguments` | text | job arguments, JSON-encoded |
+| `status` | string | `pending` / `running` / `succeeded` / `failed` |
+| `attempts` | integer | attempts made so far |
+| `max_attempts` | integer | attempts allowed before giving up |
+| `available_at` | datetime | earliest time this job may run |
+| `last_error` | text | error message from the most recent failed attempt |
+| `created_at` / `updated_at` | datetime | added automatically, like every clails table |
+
+If your project doesn't use the job queue, you never need to run this --
+nothing else in clails depends on the table existing.
+
+---
+
+## 2. Defining Jobs
+
+Use the `defjob` macro to register a job handler:
+
+```common-lisp
+(defpackage #:your-app/jobs/send-welcome-email
+  (:use #:cl)
+  (:import-from #:clails/job
+                #:defjob)
+  (:import-from #:your-app/models/user
+                #:<user>))
+
+(in-package #:your-app/jobs/send-welcome-email)
+
+(defjob :send-welcome-email
+  :description "Send a welcome email to a new user"
+  :max-attempts 5
+  :function (lambda (&key user-id)
+              (let ((user (find-user user-id)))
+                (send-mail (ref user :email) "Welcome!"))))
+```
+
+- `:function` is a lambda taking the same keyword arguments `enqueue-job`
+  is called with.
+- `:max-attempts` (default 25) is how many times the worker will attempt this
+  job, including the first attempt, before giving up and marking it `:failed`.
+  It can also be overridden per-call from `enqueue-job`.
+- Like task files, job files should be loaded as part of your application
+  (e.g. `app/jobs/*.lisp`, wired into your application loader) so `defjob`
+  has run by the time you enqueue or run jobs.
+
+A job handler that signals an error is exactly how you tell the queue to
+retry it -- just let the error propagate (or explicitly `(error ...)`)
+rather than catching it yourself, unless you want that particular failure
+to *not* count as an attempt.
+
+---
+
+## 3. Enqueuing Jobs
+
+```common-lisp
+(clails/job:enqueue-job :send-welcome-email :arguments (list :user-id 42))
+```
+
+`enqueue-job` accepts:
+
+| Argument | Description |
+|----------|-------------|
+| `job-name` | The keyword a job was registered with via `defjob` |
+| `:arguments` | Plist passed to the job's `:function` when it runs |
+| `:max-attempts` | Overrides the job's own `:max-attempts` for this call |
+| `:run-at` | Universal time at/after which the job becomes eligible to run (default: now) |
+
+```common-lisp
+;; Run as soon as a worker is free
+(enqueue-job :send-welcome-email :arguments (list :user-id 42))
+
+;; Run this job at least 5 attempts even if the job was registered with fewer
+(enqueue-job :send-welcome-email :arguments (list :user-id 42) :max-attempts 10)
+
+;; Don't run until an hour from now
+(enqueue-job :send-welcome-email
+             :arguments (list :user-id 42)
+             :run-at (+ (get-universal-time) 3600))
+```
+
+`enqueue-job` returns the new job's `id`.
+
+---
+
+## 4. Running the Worker
+
+### From the CLI
+
+```bash
+clails job:work
+```
+
+This starts the connection pool, loads your application's model metadata
+(the same startup steps `clails server` and `clails db:seed` perform), and
+then polls the `clails_jobs` table forever, running due jobs as they become
+available. Stop it with Ctrl-C.
+
+```bash
+# Poll less aggressively
+clails job:work --poll-interval 5
+```
+
+### From application code
+
+```common-lisp
+;; Run forever on the current thread
+(clails/job:run-worker-loop)
+
+;; Run on a background thread instead
+(clails/job:start-worker :poll-interval 1)
+...
+(clails/job:stop-worker)
+
+;; Run a bounded number of polls (handy for scripts/tests)
+(clails/job:run-worker-loop :max-iterations 100 :poll-interval 1)
+```
+
+`start-worker`/`stop-worker` run the poll loop on its own
+`bordeaux-threads` thread, the same threading model the rest of clails
+uses (see `clails/model/connection`); the worker thread lazily acquires its
+own pooled database connection the first time it claims or finalizes a job.
+
+---
+
+## 5. Retries and Backoff
+
+When a job's handler signals an error, the worker:
+
+1. Records the error message on the job row (`last_error`).
+2. If the job's attempt count is still below `max_attempts`, reschedules it
+   with an exponential backoff delay: `available_at` is pushed out by
+   `*default-backoff-base-seconds*` (default 5) doubled per attempt, capped
+   at `*default-backoff-max-seconds*` (default 3600) -- i.e. 5s, 10s, 20s,
+   40s, ... up to an hour. The job's `status` goes back to `pending` so any
+   worker can pick it up again once due.
+3. Otherwise, marks the job `:failed` -- it will not be retried again.
+
+```common-lisp
+;; Tune backoff globally (e.g. in tests, or if 5s is too slow/fast for
+;; your workload)
+(setf clails/job:*default-backoff-base-seconds* 1)
+(setf clails/job:*default-backoff-max-seconds* 60)
+```
+
+A job whose name isn't registered (e.g. the worker hasn't loaded the file
+that calls `defjob` for it yet) is treated the same way as a handler error:
+it is retried, giving a worker that starts up in the wrong order a chance
+to catch up, and is marked `:failed` if it's still unregistered after
+`max_attempts`.
+
+---
+
+## 6. Concurrency and Locking
+
+Claiming a job is done inside one transaction: `SELECT ... FOR UPDATE SKIP
+LOCKED` on MySQL/PostgreSQL, or a `BEGIN IMMEDIATE` transaction on SQLite3
+(the same transaction-mode mechanism
+`clails/model/lock:with-locked-transaction` uses for pessimistic locking --
+see [document/model.md](model.md#8-pessimistic-locking)), followed by an
+`UPDATE` that marks the row `running` and increments its attempt count. This
+means it's safe to run more than one worker (multiple threads, or multiple
+`clails job:work` processes) against the same table: a row can only ever be
+claimed by one of them.
+
+What this queue does **not** provide is cross-process coordination beyond
+that row-level claim -- there's no leader election, no distributed
+scheduling, no cross-node rate limiting. For a single application talking to
+one database, that's normally all you need.
+
+---
+
+## 7. Full Worked Example
+
+```common-lisp
+;; app/jobs/send-email.lisp
+(defpackage #:your-app/jobs/send-email
+  (:use #:cl)
+  (:import-from #:clails/job
+                #:defjob)
+  (:import-from #:clails/logger/core
+                #:log.job))
+
+(in-package #:your-app/jobs/send-email)
+
+(defjob :send-email
+  :description "Send a transactional email"
+  :max-attempts 5
+  :function (lambda (&key to subject body)
+              (log.job "Sending email" :to to :subject subject)
+              (your-app/mailer:deliver :to to :subject subject :body body)))
+```
+
+```common-lisp
+;; somewhere in a controller action, after creating an order:
+(clails/job:enqueue-job :send-email
+                        :arguments (list :to (ref order :customer-email)
+                                        :subject "Order confirmed"
+                                        :body (render-order-confirmation order)))
+```
+
+```bash
+# one-time setup
+clails generate:job-queue-setup
+clails db:migrate
+
+# in a separate process/terminal, keep the worker running
+clails job:work
+```
+
+If `your-app/mailer:deliver` raises an error (say, the mail server is
+briefly unreachable), the job is retried automatically: 5s later, then 10s,
+20s, and 40s later, for a total of 5 attempts, before being marked `:failed`
+with the underlying error recorded in `last_error` for you to inspect
+(e.g. `select * from clails_jobs where status = 'failed'`).
+
+---
+
+## 8. Future Directions
+
+Deliberately left out of this first version, as separate, larger design
+decisions:
+
+- **External broker integration** (Redis/Sidekiq, RabbitMQ, SQS, ...) for
+  applications that need cross-process/cross-language queues or higher
+  throughput than a polled DB table can offer. This would be an alternative
+  backend behind the same `enqueue-job`/`defjob` API, not a replacement for
+  it, and would add a new required dependency, so it's left for a follow-up
+  proposal.
+- **A web dashboard** for inspecting pending/failed jobs (a la Sidekiq Web
+  or `good_job`'s dashboard).
+- **Cron-style recurring schedules** ("every day at 2am") on top of the
+  existing one-shot `:run-at` scheduling.
+- **Per-queue/priority support** (multiple named queues, worker
+  concurrency limits per queue).
+
+---
+
+## 9. Troubleshooting
+
+### Jobs never run
+
+- Is a worker actually running (`clails job:work`, or
+  `start-worker`/`run-worker-loop` in your application)?
+- Does the `clails_jobs` table exist (`clails generate:job-queue-setup` +
+  `clails db:migrate`)?
+- Check `available_at` on the row -- a job enqueued with a future `:run-at`
+  won't be claimed until then.
+
+### Job immediately fails with "No job registered for name ..."
+
+The worker process hasn't loaded the file that calls `defjob` for that job
+name. Make sure your job files are loaded as part of application startup,
+the same way models and controllers are.
+
+### A job keeps retrying and never succeeds
+
+Check `last_error` on the row for the underlying exception message; the
+job will be marked `:failed` once it reaches `max_attempts`.
+
+---
+
+## 10. Summary
+
+- Define job handlers with `defjob`, persist work with `enqueue-job`
+- Run `clails generate:job-queue-setup` once, then `clails db:migrate`, to
+  create the `clails_jobs` table
+- Run a worker with `clails job:work` (or `run-worker-loop`/`start-worker`
+  from code)
+- Failures retry automatically with exponential backoff up to
+  `max-attempts`, then land in `:failed` with the error recorded
+
+Reach for the job queue whenever you'd otherwise be tempted to do
+slow/unreliable work (sending email, calling a third-party API, processing
+an upload) directly on the request path.

--- a/document/job-queue_ja.md
+++ b/document/job-queue_ja.md
@@ -1,0 +1,331 @@
+# clails ジョブキューガイド
+
+## 概要
+
+このガイドでは、clailsのバックグラウンドジョブキューについて説明します。
+
+[タスクシステム](task_ja.md)（`deftask`/`clails task`）がCLIから一度だけ同期的に
+コマンドを実行するのに対し、ジョブキューはアプリケーションコードから「後で実行する
+処理」をキューに積んでおき、リクエスト処理から切り離してワーカープロセスに実行させる
+ための機能です。他のフレームワークでいうSidekiqやActiveJobに相当します。
+ジョブはデータベースのテーブルに永続化されるため（外部ブローカーは不要）、ワーカーの
+再起動をまたいでも消えず、ハンドラがエラーを送出した場合は指数バックオフで自動的に
+リトライされます。
+
+## 基本概念
+
+- ジョブのハンドラは`defjob`マクロで定義（`deftask`の非同期版）
+- `enqueue-job`でジョブを`clails_jobs`テーブルに永続化し、後で実行されるようにする
+- ワーカー（`clails/job:run-worker-loop`、またはCLIの`clails job:work`）が
+  このテーブルをポーリングし、実行期限が来たジョブを実行する
+- 失敗したジョブは指数バックオフでリトライされ、成功するか`:max-attempts`に
+  達すると`:failed`としてエラー内容とともに記録される
+- `clails_jobs`テーブルは通常のマイグレーションで作成される。
+  `db:migrate`/`db:rollback`の扱いに特別な点はない
+
+## スコープ
+
+このジョブキューは意図的に小さく、単一プロセス向けに設計されています。
+
+- **対象範囲**: ジョブの永続化、実行期限が来たジョブをワーカーが取得して実行、
+  `:max-attempts`まで指数バックオフでリトライ、指定時刻以降に実行（`:run-at`）
+- **対象外**（現時点では）: 外部ブローカー（Redis/Sidekiq的なもの） --
+  キューは完全にDB永続化のみで実現しています。ジョブを確認するためのWeb
+  ダッシュボード。cron的な定期実行スケジュール（ジョブは`:run-at`以降に
+  一度だけ実行されます）。[今後の方向性](#8-今後の方向性)を参照してください。
+
+---
+
+## 1. `clails_jobs`テーブルのセットアップ
+
+ジョブキューにはジョブを永続化するテーブルが必要です。他のマイグレーションと
+同じ要領で一度だけ生成し、実行してください。
+
+```bash
+clails generate:job-queue-setup
+clails db:migrate
+```
+
+`generate:job-queue-setup`は、`clails_jobs`テーブルの定義
+（`template/generate/job-queue-migration.lisp.tmpl`参照）が
+あらかじめ書き込まれた、通常のマイグレーションファイルを`db/migrate/`に
+生成するだけです。新しいマイグレーションの仕組みを覚える必要はありません。
+以下のカラムが作成されます。
+
+| カラム | 型 | 説明 |
+|--------|------|------|
+| `id` | integer | 主キー（clailsの全テーブルと同様に自動付与） |
+| `job_name` | string | `defjob`で登録したジョブ名 |
+| `arguments` | text | ジョブの引数（JSONエンコード） |
+| `status` | string | `pending` / `running` / `succeeded` / `failed` |
+| `attempts` | integer | これまでの試行回数 |
+| `max_attempts` | integer | 諦めるまでに許容する試行回数 |
+| `available_at` | datetime | このジョブを実行してよい最も早い時刻 |
+| `last_error` | text | 直近の失敗時のエラーメッセージ |
+| `created_at` / `updated_at` | datetime | clailsの全テーブルと同様に自動付与 |
+
+プロジェクトでジョブキューを使わないのであれば、このテーブルを作成する
+必要は一切ありません。他のclailsの機能はこのテーブルの存在を前提としません。
+
+---
+
+## 2. ジョブの定義
+
+`defjob`マクロを使ってジョブのハンドラを登録します。
+
+```common-lisp
+(defpackage #:your-app/jobs/send-welcome-email
+  (:use #:cl)
+  (:import-from #:clails/job
+                #:defjob)
+  (:import-from #:your-app/models/user
+                #:<user>))
+
+(in-package #:your-app/jobs/send-welcome-email)
+
+(defjob :send-welcome-email
+  :description "新規ユーザーにウェルカムメールを送信"
+  :max-attempts 5
+  :function (lambda (&key user-id)
+              (let ((user (find-user user-id)))
+                (send-mail (ref user :email) "ようこそ！"))))
+```
+
+- `:function`には、`enqueue-job`に渡したのと同じキーワード引数を受け取る
+  ラムダを指定します。
+- `:max-attempts`（デフォルト25）は、このジョブを`:failed`として諦めるまでに
+  ワーカーが試行する回数（1回目の実行を含む）です。`enqueue-job`呼び出し側で
+  上書きすることもできます。
+- タスクファイルと同様、ジョブファイルはアプリケーションの一部として
+  読み込まれるようにしてください（例: `app/jobs/*.lisp`をアプリケーション
+  ローダーに組み込む）。ジョブをenqueueしたりワーカーを実行したりする
+  時点までに`defjob`が実行されている必要があります。
+
+ジョブハンドラがエラーを送出することが、そのままキューに対する
+「リトライしてほしい」という合図になります。よほどの理由がない限り、
+ハンドラ内でエラーを自分で握りつぶさず、そのまま伝播（あるいは明示的に
+`(error ...)`）させてください。
+
+---
+
+## 3. ジョブのenqueue
+
+```common-lisp
+(clails/job:enqueue-job :send-welcome-email :arguments (list :user-id 42))
+```
+
+`enqueue-job`は以下を受け取ります。
+
+| 引数 | 説明 |
+|------|------|
+| `job-name` | `defjob`で登録したキーワード |
+| `:arguments` | 実行時に`:function`へ渡すplist |
+| `:max-attempts` | この呼び出しに限りジョブ自身の`:max-attempts`を上書き |
+| `:run-at` | このジョブが実行可能になる時刻（universal time）。省略時は即時 |
+
+```common-lisp
+;; ワーカーが空き次第すぐ実行
+(enqueue-job :send-welcome-email :arguments (list :user-id 42))
+
+;; 登録時より多くリトライさせたい場合
+(enqueue-job :send-welcome-email :arguments (list :user-id 42) :max-attempts 10)
+
+;; 1時間後まで実行しない
+(enqueue-job :send-welcome-email
+             :arguments (list :user-id 42)
+             :run-at (+ (get-universal-time) 3600))
+```
+
+`enqueue-job`は作成されたジョブの`id`を返します。
+
+---
+
+## 4. ワーカーの実行
+
+### CLIから
+
+```bash
+clails job:work
+```
+
+コネクションプールを起動し、アプリケーションのモデルのメタ情報を読み込んだ上で
+（`clails server`や`clails db:seed`と同じ起動処理）、`clails_jobs`テーブルを
+永続的にポーリングし、実行期限が来たジョブを順次実行します。Ctrl-Cで停止します。
+
+```bash
+# ポーリング間隔を広げる
+clails job:work --poll-interval 5
+```
+
+### アプリケーションコードから
+
+```common-lisp
+;; 現在のスレッドで無限に実行
+(clails/job:run-worker-loop)
+
+;; 別スレッドで実行
+(clails/job:start-worker :poll-interval 1)
+...
+(clails/job:stop-worker)
+
+;; 回数を区切って実行（スクリプトやテストで便利）
+(clails/job:run-worker-loop :max-iterations 100 :poll-interval 1)
+```
+
+`start-worker`/`stop-worker`は、clailsの他の部分と同じスレッドモデル
+（`clails/model/connection`参照）である`bordeaux-threads`のスレッド上で
+ポーリングループを実行します。ワーカースレッドは、ジョブを取得または
+完了させる最初のタイミングで、遅延的に自分専用のプールコネクションを取得します。
+
+---
+
+## 5. リトライとバックオフ
+
+ジョブのハンドラがエラーを送出すると、ワーカーは以下を行います。
+
+1. エラーメッセージをジョブの行に記録する（`last_error`）。
+2. 試行回数がまだ`max_attempts`未満であれば、指数バックオフの遅延で
+   再スケジュールする。`available_at`は`*default-backoff-base-seconds*`
+   （デフォルト5秒）を試行のたびに倍にした値だけ先に延ばされ、
+   `*default-backoff-max-seconds*`（デフォルト3600秒）で頭打ちになります
+   （5秒、10秒、20秒、40秒、…と最大1時間まで）。ジョブの`status`は
+   `pending`に戻るため、どのワーカーでも実行期限が来れば再度取得できます。
+3. そうでなければ、ジョブを`:failed`として記録します。これ以降は
+   リトライされません。
+
+```common-lisp
+;; バックオフの間隔をグローバルに調整する
+;; （テストで使う場合や、5秒では速すぎ/遅すぎる場合など）
+(setf clails/job:*default-backoff-base-seconds* 1)
+(setf clails/job:*default-backoff-max-seconds* 60)
+```
+
+登録されていない名前のジョブ（例えば、`defjob`を呼ぶファイルをまだ
+ワーカーが読み込んでいない場合）も、ハンドラのエラーと同様に扱われます。
+起動順序がずれて先にワーカーが立ち上がった場合でも、後から追いつく
+チャンスとしてリトライされ、`max_attempts`に達してもまだ未登録であれば
+`:failed`になります。
+
+---
+
+## 6. 並行性とロック
+
+ジョブの取得（claim）は1つのトランザクション内で行われます。
+MySQL/PostgreSQLでは`SELECT ... FOR UPDATE SKIP LOCKED`、SQLite3では
+`BEGIN IMMEDIATE`トランザクション（悲観的ロックのために
+`clails/model/lock:with-locked-transaction`が使っているのと同じ
+トランザクションモードの仕組みです。[document/model_ja.md](model_ja.md#8-悲観的ロック)
+を参照）を使い、その後に行を`running`にして試行回数を増やす`UPDATE`を
+実行します。そのため、同じテーブルに対して複数のワーカー（複数スレッド、
+あるいは複数の`clails job:work`プロセス）を動かしても安全です。1つの行が
+複数のワーカーに同時に取得されることはありません。
+
+一方で、この行単位のclaim以上のプロセス間協調（リーダー選出、分散
+スケジューリング、ノードをまたいだレート制御など）は提供していません。
+1つのデータベースに対して1つのアプリケーションが動く構成であれば、
+通常はこれで十分です。
+
+---
+
+## 7. 完全な使用例
+
+```common-lisp
+;; app/jobs/send-email.lisp
+(defpackage #:your-app/jobs/send-email
+  (:use #:cl)
+  (:import-from #:clails/job
+                #:defjob)
+  (:import-from #:clails/logger/core
+                #:log.job))
+
+(in-package #:your-app/jobs/send-email)
+
+(defjob :send-email
+  :description "トランザクションメールを送信"
+  :max-attempts 5
+  :function (lambda (&key to subject body)
+              (log.job "メール送信中" :to to :subject subject)
+              (your-app/mailer:deliver :to to :subject subject :body body)))
+```
+
+```common-lisp
+;; 注文作成後、コントローラのアクションなどから
+(clails/job:enqueue-job :send-email
+                        :arguments (list :to (ref order :customer-email)
+                                        :subject "ご注文確認"
+                                        :body (render-order-confirmation order)))
+```
+
+```bash
+# 初回のみ
+clails generate:job-queue-setup
+clails db:migrate
+
+# 別プロセス/別ターミナルでワーカーを起動し続ける
+clails job:work
+```
+
+`your-app/mailer:deliver`がエラーを送出した場合（メールサーバーに
+一時的に接続できない、など）、ジョブは自動的にリトライされます。5秒後、
+10秒後、20秒後、40秒後と合計5回試行した後、`:failed`となり、元の
+エラーが`last_error`に記録されるので、後から確認できます
+（例: `select * from clails_jobs where status = 'failed'`）。
+
+---
+
+## 8. 今後の方向性
+
+今回は意図的に対象外とした、より大きな設計判断が必要な項目です。
+
+- **外部ブローカー連携**（Redis/Sidekiq、RabbitMQ、SQSなど）。
+  プロセスや言語をまたいだキューや、ポーリング型のDBテーブルより高い
+  スループットが必要なアプリケーション向け。これは
+  `enqueue-job`/`defjob`という同じAPIの背後にある別バックエンドとして
+  追加されるべきものであり、現在の仕組みの置き換えではありません。
+  新たな必須依存が増えるため、別途の提案に委ねます。
+- 保留中・失敗したジョブを確認するための**Webダッシュボード**
+  （Sidekiq Webや`good_job`のダッシュボードに相当するもの）。
+- 既存の一度きりの`:run-at`スケジューリングに加えた、**cron的な
+  定期実行スケジュール**（「毎日午前2時に」など）。
+- **キュー/優先度のサポート**（複数の名前付きキュー、キューごとの
+  ワーカー同時実行数の制御）。
+
+---
+
+## 9. トラブルシューティング
+
+### ジョブが実行されない
+
+- ワーカーは実際に動いていますか（`clails job:work`、あるいは
+  アプリケーション内の`start-worker`/`run-worker-loop`）？
+- `clails_jobs`テーブルは存在しますか（`clails generate:job-queue-setup`
+  と`clails db:migrate`）？
+- 行の`available_at`を確認してください。未来の`:run-at`でenqueueされた
+  ジョブは、その時刻になるまで取得されません。
+
+### ジョブがすぐに「No job registered for name ...」で失敗する
+
+ワーカープロセスが、そのジョブ名を`defjob`しているファイルを読み込んで
+いません。モデルやコントローラと同様に、ジョブファイルがアプリケーション
+起動時に読み込まれるようにしてください。
+
+### ジョブがリトライを繰り返して成功しない
+
+行の`last_error`で元の例外メッセージを確認してください。
+`max_attempts`に達すると、ジョブは`:failed`になります。
+
+---
+
+## 10. まとめ
+
+- `defjob`でジョブのハンドラを定義し、`enqueue-job`で処理をキューに積む
+- `clails generate:job-queue-setup`を一度実行し、続けて`clails db:migrate`
+  を実行して`clails_jobs`テーブルを作成する
+- `clails job:work`（またはコードから`run-worker-loop`/`start-worker`）で
+  ワーカーを実行する
+- 失敗したジョブは`max-attempts`まで指数バックオフで自動的にリトライされ、
+  それでも失敗した場合はエラーとともに`:failed`になる
+
+メール送信や外部APIの呼び出し、アップロードされたファイルの処理など、
+遅かったり失敗しうる処理をリクエスト処理の中で直接行いたくなったときは、
+ジョブキューの利用を検討してください。

--- a/roswell/clails.ros
+++ b/roswell/clails.ros
@@ -25,6 +25,7 @@ exec ros -Q -- $0 "$@"
   (format t "  generate:controller <name>        Generate controller file~%")
   (format t "  generate:scaffold <name>          Generate scaffold~%")
   (format t "  generate:task <name>              Generate task file~%")
+  (format t "  generate:job-queue-setup          Generate the job queue migration~%")
   (format t "  db:create                         Create database~%")
   (format t "  db:migrate                        Run migrations~%")
   (format t "  db:migrate:up <version>           Migrate up to version~%")
@@ -32,6 +33,7 @@ exec ros -Q -- $0 "$@"
   (format t "  db:rollback                       Rollback migrations~%")
   (format t "  db:status                         Show migration status~%")
   (format t "  task [TASK] [OPTIONS]             Execute custom tasks~%")
+  (format t "  job:work [OPTIONS]                Run the background job worker~%")
   (format t "  test [packages...]                Run tests~%")
   (format t "  server                            Start web server~%")
   (format t "  stop                              Stop web server~%")
@@ -61,6 +63,7 @@ exec ros -Q -- $0 "$@"
   (format t "  generate:controller <name>        Generate controller file~%")
   (format t "  generate:scaffold <name>          Generate model, view, and controller~%")
   (format t "  generate:task <name>              Generate task file~%")
+  (format t "  generate:job-queue-setup          Generate the migration for the clails_jobs table~%")
   (format t "~%")
   (format t "Options:~%")
   (format t "  --no-overwrite            Do not overwrite existing files (not available for migration)~%")
@@ -70,7 +73,8 @@ exec ros -Q -- $0 "$@"
   (format t "Examples:~%")
   (format t "  clails generate:task cleanup~%")
   (format t "  clails generate:task import --namespace data~%")
-  (format t "  clails generate:task cleanup -ns maintenance~%"))
+  (format t "  clails generate:task cleanup -ns maintenance~%")
+  (format t "  clails generate:job-queue-setup    # then: clails db:migrate~%"))
 
 (defun help/db ()
   (format t "Usage: clails db:COMMAND [OPTIONS]~%~%")
@@ -162,6 +166,19 @@ exec ros -Q -- $0 "$@"
   (format t "  clails task --list db                     # List tasks in 'db' namespace~%")
   (format t "  clails task --info maintenance:cleanup    # Show info about db:migrate task~%")
   (format t "  clails task maintenance:cleanup           # Run custom task~%"))
+
+(defun help/job ()
+  (format t "Usage: clails job:work [OPTIONS]~%~%")
+  (format t "Run the background job worker: polls the clails_jobs table (see~%")
+  (format t "'clails generate:job-queue-setup') and executes due jobs defined with~%")
+  (format t "defjob/enqueued with enqueue-job, retrying failed jobs with exponential~%")
+  (format t "backoff up to each job's max-attempts.~%~%")
+  (format t "Options:~%")
+  (format t "  --poll-interval SECONDS   Seconds to sleep between polls that found no due job (default: 1)~%")
+  (format t "  -h, --help                Show this help message~%~%")
+  (format t "Examples:~%")
+  (format t "  clails job:work~%")
+  (format t "  clails job:work --poll-interval 5~%"))
 
 ;; Utility functions
 (defun load-project ()
@@ -402,6 +419,15 @@ exec ros -Q -- $0 "$@"
     (load-project)
     (clails/cmd:generate/migration migration-name)))
 
+(define-command "generate:job-queue-setup" (&key (help :short-option "h"
+                                                        :long-option "help"))
+  (:help-function #'help/generate)
+  (when help
+    (help/generate)
+    (uiop:quit 0))
+  (load-project)
+  (clails/cmd:generate/job-queue-setup))
+
 (define-command "generate:view" (args &key (no-overwrite :long-option "no-overwrite")
                                            (help :short-option "h"
                                                  :long-option "help"))
@@ -600,6 +626,20 @@ exec ros -Q -- $0 "$@"
     (t
      (help/task)
      (uiop:quit 0))))
+
+(define-command "job:work" (&key (poll-interval :long-option "poll-interval"
+                                                :consume t)
+                                 (help :short-option "h"
+                                       :long-option "help"))
+  (:help-function #'help/job)
+  (when help
+    (help/job)
+    (uiop:quit 0))
+  (load-project)
+  (load-db-package)
+  (if poll-interval
+      (clails/cmd:job/work :poll-interval (read-from-string poll-interval))
+      (clails/cmd:job/work)))
 
 
 (defun main (&rest argv)

--- a/src/cmd.lisp
+++ b/src/cmd.lisp
@@ -9,6 +9,7 @@
   (:import-from #:clails/project/generate
                 #:gen/model
                 #:gen/migration
+                #:gen/job-queue-migration
                 #:gen/view
                 #:gen/controller
                 #:gen/scaffold
@@ -46,9 +47,12 @@
   (:import-from #:clails/task
                 #:initialize-task-system
                 #:run-task)
+  (:import-from #:clails/job
+                #:run-worker-loop)
   (:export #:create-project
            #:generate/model
            #:generate/migration
+           #:generate/job-queue-setup
            #:generate/view
            #:generate/controller
            #:generate/scaffold
@@ -66,7 +70,8 @@
            #:test
            #:task/run
            #:task/list
-           #:task/info))
+           #:task/info
+           #:job/work))
 (in-package #:clails/cmd)
 
 (defparameter *app* nil
@@ -134,6 +139,15 @@
    @return [t] Generation result
    "
   (gen/migration migration-name))
+
+(defun generate/job-queue-setup ()
+  "Generate the migration that creates the clails_jobs table used by the
+   background job queue (clails/job:enqueue-job). Run 'clails db:migrate'
+   afterwards to apply it. See document/job-queue.md.
+
+   @return [t] Generation result
+   "
+  (gen/job-queue-migration))
 
 (defun generate/view (view-name &key (no-overwrite T))
   "Generate a view template file.
@@ -528,3 +542,23 @@
           (progn
             (format *error-output* "Error: Task not found: ~A~%" task-name-str)
             (uiop:quit 1))))))
+
+(defun job/work (&key (poll-interval 1) max-iterations)
+  "Run the background job worker, claiming and executing due jobs from the
+   clails_jobs table (see clails/job:enqueue-job) until stopped.
+
+   Requires the clails_jobs table to already exist -- see
+   'clails generate:job-queue-setup' and document/job-queue.md. Blocks until
+   interrupted (Ctrl-C) unless max-iterations is given.
+
+   @param poll-interval [number] Seconds to sleep between polls that found no
+                                 due job (default: 1)
+   @param max-iterations [integer or nil] Stop after this many poll
+                                          iterations (nil = run forever)
+   @return [nil]
+   "
+  (startup-connection-pool)
+  (initialize-table-information)
+  (unwind-protect
+      (run-worker-loop :poll-interval poll-interval :max-iterations max-iterations)
+    (shutdown-connection-pool)))

--- a/src/job.lisp
+++ b/src/job.lisp
@@ -1,0 +1,84 @@
+;;;; Job System
+;;;; Main integration package for the background job queue.
+;;;;
+;;;; See document/job-queue.md for a full walkthrough. In short:
+;;;;
+;;;;   (defjob :send-welcome-email
+;;;;     :max-attempts 5
+;;;;     :function (lambda (&key user-id) ...))
+;;;;
+;;;;   (enqueue-job :send-welcome-email :arguments (list :user-id 42))
+;;;;
+;;;;   (run-worker-loop)                     ; or (start-worker), (stop-worker)
+
+(defpackage #:clails/job
+  (:use #:cl)
+  (:import-from #:clails/job/registry
+                #:register-job
+                #:find-job
+                #:list-jobs
+                #:job-exists-p
+                #:remove-job
+                #:clear-registry
+                #:make-job-info
+                #:job-info-name
+                #:job-info-description
+                #:job-info-max-attempts
+                #:job-info-function)
+  (:import-from #:clails/job/core
+                #:defjob)
+  (:import-from #:clails/job/queue
+                #:*jobs-table-name*
+                #:*default-max-attempts*
+                #:*default-backoff-base-seconds*
+                #:*default-backoff-max-seconds*
+                #:enqueue-job
+                #:claim-due-job
+                #:mark-job-succeeded
+                #:mark-job-retry
+                #:mark-job-failed
+                #:backoff-seconds
+                #:job-plist-id
+                #:job-plist-job-name
+                #:job-plist-arguments
+                #:job-plist-attempts
+                #:job-plist-max-attempts)
+  (:import-from #:clails/job/worker
+                #:run-worker-tick
+                #:run-worker-loop
+                #:start-worker
+                #:stop-worker
+                #:worker-running-p)
+  (:export #:register-job
+           #:find-job
+           #:list-jobs
+           #:job-exists-p
+           #:remove-job
+           #:clear-registry
+           #:make-job-info
+           #:job-info-name
+           #:job-info-description
+           #:job-info-max-attempts
+           #:job-info-function
+           #:defjob
+           #:*jobs-table-name*
+           #:*default-max-attempts*
+           #:*default-backoff-base-seconds*
+           #:*default-backoff-max-seconds*
+           #:enqueue-job
+           #:claim-due-job
+           #:mark-job-succeeded
+           #:mark-job-retry
+           #:mark-job-failed
+           #:backoff-seconds
+           #:job-plist-id
+           #:job-plist-job-name
+           #:job-plist-arguments
+           #:job-plist-attempts
+           #:job-plist-max-attempts
+           #:run-worker-tick
+           #:run-worker-loop
+           #:start-worker
+           #:stop-worker
+           #:worker-running-p))
+(in-package #:clails/job)

--- a/src/job/core.lisp
+++ b/src/job/core.lisp
@@ -1,0 +1,45 @@
+;;;; Job Core
+;;;; DSL for defining background jobs
+
+(defpackage #:clails/job/core
+  (:use #:cl)
+  (:import-from #:clails/job/registry
+                #:register-job)
+  (:export #:defjob))
+
+(in-package #:clails/job/core)
+
+(defmacro defjob (name &key description (max-attempts 25) function)
+  "Define a background job handler.
+
+   Jobs defined with defjob are executed asynchronously by the job worker
+   (see clails/job/worker), after being persisted with enqueue-job. This is
+   the asynchronous sibling of clails/task:deftask: where deftask registers a
+   one-shot, synchronous, rake-style command, defjob registers a handler that
+   the worker looks up by name and runs later, with automatic retry/backoff.
+
+   Example:
+     (defjob :send-welcome-email
+       :description \"Send a welcome email to a new user\"
+       :max-attempts 5
+       :function (lambda (&key user-id)
+                   (send-mail (find-user-email user-id) \"Welcome!\")))
+
+     (enqueue-job :send-welcome-email :arguments (list :user-id 42))
+
+   @param name [keyword] Job name, used both to register the handler and to
+                         look it up when the worker claims a persisted job
+   @param description [string or nil] Job description (optional)
+   @param max-attempts [integer] Default number of attempts (including the
+                                 first) before a failing job is marked
+                                 :failed instead of retried (default: 25).
+                                 Can be overridden per-call via
+                                 (enqueue-job ... :max-attempts n)
+   @param function [form] Job implementation (should be a lambda form taking
+                          the keyword arguments passed to enqueue-job)
+   @return [keyword] The registered job name
+   "
+  `(register-job ',name
+                 :description ,description
+                 :max-attempts ,max-attempts
+                 :function ,function))

--- a/src/job/queue.lisp
+++ b/src/job/queue.lisp
@@ -1,0 +1,347 @@
+;;;; Job Queue
+;;;; DB-persisted job queue: enqueue, claim, and finalize jobs.
+;;;;
+;;;; Jobs are stored in a plain database table (see
+;;;; template/generate/job-queue-migration.lisp.tmpl for the schema) rather
+;;;; than as a clails/model/base-model:defmodel-backed model. A defmodel
+;;;; class is introspected from the database the moment
+;;;; initialize-table-information runs (typically at server/console/worker
+;;;; boot), for every registered model -- which would mean every clails
+;;;; application would need the jobs table to exist just to boot, even if it
+;;;; never uses the job queue. Talking to the table with plain SQL (the same
+;;;; approach clails/model/migration itself uses for its own "migration"
+;;;; bookkeeping table) keeps the feature fully opt-in: nothing breaks until
+;;;; the application actually calls enqueue-job/starts a worker, at which
+;;;; point the table is expected to exist (see document/job-queue.md).
+;;;;
+;;;; Claiming a due job still reuses the same pessimistic-locking primitives
+;;;; documented in document/model.md (SELECT ... FOR UPDATE for
+;;;; MySQL/PostgreSQL; BEGIN IMMEDIATE, the same mechanism
+;;;; clails/model/lock:with-locked-transaction relies on, for SQLite3) so
+;;;; that only one worker can ever claim a given row.
+
+(defpackage #:clails/job/queue
+  (:use #:cl)
+  (:import-from #:clails/environment
+                #:*database-type*
+                #:<database-type-mysql>
+                #:<database-type-postgresql>
+                #:<database-type-sqlite3>
+                #:*sqlite3-transaction-mode*)
+  (:import-from #:clails/model/connection
+                #:get-connection
+                #:with-db-connection)
+  (:import-from #:clails/model/transaction
+                #:with-transaction)
+  (:import-from #:clails/model/query
+                #:get-last-id-impl)
+  (:import-from #:clails/job/registry
+                #:find-job
+                #:job-info-max-attempts)
+  (:import-from #:clails/logger/core
+                #:log.job)
+  (:import-from #:jonathan
+                #:to-json
+                #:parse)
+  (:export #:*jobs-table-name*
+           #:*default-max-attempts*
+           #:*default-backoff-base-seconds*
+           #:*default-backoff-max-seconds*
+           #:enqueue-job
+           #:claim-due-job
+           #:mark-job-succeeded
+           #:mark-job-retry
+           #:mark-job-failed
+           #:backoff-seconds
+           #:job-plist-id
+           #:job-plist-job-name
+           #:job-plist-arguments
+           #:job-plist-attempts
+           #:job-plist-max-attempts))
+
+(in-package #:clails/job/queue)
+
+(defparameter *jobs-table-name* "clails_jobs"
+  "Name of the framework-provided job queue table. See
+   template/generate/job-queue-migration.lisp.tmpl.")
+
+(defparameter *default-max-attempts* 25
+  "Default number of attempts (including the first) before a failing job is
+   marked :failed instead of retried, used when neither enqueue-job nor the
+   job's defjob specify :max-attempts.")
+
+(defparameter *default-backoff-base-seconds* 5
+  "Base delay, in seconds, for the exponential backoff applied between retry
+   attempts: delay = base * 2^(attempt-number - 1), capped at
+   *default-backoff-max-seconds*.")
+
+(defparameter *default-backoff-max-seconds* 3600
+  "Upper bound, in seconds, on the exponential backoff delay between retries.")
+
+
+;;;; ----------------------------------------
+;;;; datetime helpers
+;;;;
+;;;; The clails ORM stores DATETIME/TIMESTAMP values as Lisp universal-time
+;;;; integers and converts them to/from "YYYY-MM-DD HH:MM:SS" strings inside
+;;;; each database backend's per-column :cl-db-fn/:db-cl-fn (see
+;;;; src/model/impl/{mysql,postgresql,sqlite3}.lisp). That machinery is keyed
+;;;; off a model's introspected column list, which the raw-SQL job queue
+;;;; does not have, so the same conversion is reimplemented here directly.
+
+(defun ut->db-string (universal-time)
+  "Format a universal-time integer as a \"YYYY-MM-DD HH:MM:SS\" string
+   suitable for binding to a DATETIME/TIMESTAMP column on any supported
+   backend.
+
+   @param universal-time [integer] Universal time
+   @return [string] Formatted datetime string
+   "
+  (multiple-value-bind (sec min hour date month year)
+      (decode-universal-time universal-time)
+    (format nil "~4,'0d-~2,'0d-~2,'0d ~2,'0d:~2,'0d:~2,'0d" year month date hour min sec)))
+
+(defun db-value->ut (value)
+  "Normalize a DATETIME/TIMESTAMP column value fetched from any supported
+   backend to a universal-time integer.
+
+   MySQL/PostgreSQL drivers hand back a universal-time integer already;
+   SQLite3 hands back the raw \"YYYY-MM-DD HH:MM:SS\" string.
+
+   @param value [integer, string, or nil] Raw fetched column value
+   @return [integer or nil] Universal time
+   "
+  (cond
+    ((null value) nil)
+    ((integerp value) value)
+    ((stringp value)
+     (encode-universal-time (parse-integer value :start 17 :end 19)
+                            (parse-integer value :start 14 :end 16)
+                            (parse-integer value :start 11 :end 13)
+                            (parse-integer value :start 8 :end 10)
+                            (parse-integer value :start 5 :end 7)
+                            (parse-integer value :start 0 :end 4)))
+    (t (error "Unexpected datetime value fetched from ~A: ~S" *jobs-table-name* value))))
+
+(defun job-name->db-string (job-name)
+  (string-downcase (string job-name)))
+
+(defun db-string->job-name (string)
+  (intern (string-upcase string) :keyword))
+
+(defun normalize-text-value (value)
+  "MySQL's driver hands TEXT/BLOB column values back as raw
+   (vector (unsigned-byte 8)) octets rather than Lisp strings (the same
+   thing src/model/impl/mysql.lisp's :text :db-cl-fn works around for
+   model-backed columns); PostgreSQL/SQLite3 already hand back strings.
+   Normalize either to a string.
+
+   @param value [string, octet-vector, or nil] Raw fetched TEXT column value
+   @return [string or nil]
+   "
+  (typecase value
+    ((vector (unsigned-byte 8)) (babel:octets-to-string value))
+    (t value)))
+
+(defun encode-arguments (arguments)
+  (to-json (or arguments '()) :from :plist))
+
+(defun decode-arguments (json)
+  (let ((json (normalize-text-value json)))
+    (if (and json (> (length json) 0))
+        (parse json :as :plist)
+        nil)))
+
+
+;;;; ----------------------------------------
+;;;; row <-> plist
+
+(defun row->job-plist (row)
+  "Convert a raw database row (plist with snake_case keys, as returned by
+   dbi-cp:fetch) into a normalized job plist.
+
+   @param row [plist] Raw row
+   @return [plist] Normalized job plist with keys :id :job-name :arguments
+                   :status :attempts :max-attempts :available-at :last-error
+                   :created-at :updated-at
+   "
+  (list :id (getf row :|id|)
+        :job-name (db-string->job-name (getf row :|job_name|))
+        :arguments (decode-arguments (getf row :|arguments|))
+        :status (getf row :|status|)
+        :attempts (getf row :|attempts|)
+        :max-attempts (getf row :|max_attempts|)
+        :available-at (db-value->ut (getf row :|available_at|))
+        :last-error (normalize-text-value (getf row :|last_error|))
+        :created-at (db-value->ut (getf row :|created_at|))
+        :updated-at (db-value->ut (getf row :|updated_at|))))
+
+(defun job-plist-id (job) (getf job :id))
+(defun job-plist-job-name (job) (getf job :job-name))
+(defun job-plist-arguments (job) (getf job :arguments))
+(defun job-plist-attempts (job) (getf job :attempts))
+(defun job-plist-max-attempts (job) (getf job :max-attempts))
+
+
+;;;; ----------------------------------------
+;;;; enqueue
+
+(defun enqueue-job (job-name &key arguments max-attempts run-at)
+  "Persist a new job to the queue.
+
+   @param job-name [keyword] Job name (see defjob)
+   @param arguments [plist] Arguments passed to the job handler when it runs
+   @param max-attempts [integer or nil] Maximum attempts before the job is
+                                        marked :failed. When nil, uses the
+                                        max-attempts the job was registered
+                                        with via defjob, falling back to
+                                        *default-max-attempts* if the job
+                                        isn't registered (yet) in this
+                                        process.
+   @param run-at [integer or nil] Universal time at/after which the job
+                                  becomes eligible to run. Defaults to now
+                                  (run as soon as a worker is free).
+   @return [integer] id of the newly inserted job row
+   "
+  (let* ((now (get-universal-time))
+         (job-info (find-job job-name))
+         (resolved-max-attempts (or max-attempts
+                                    (and job-info (job-info-max-attempts job-info))
+                                    *default-max-attempts*))
+         (available-at (ut->db-string (or run-at now)))
+         (now-string (ut->db-string now))
+         (arguments-json (encode-arguments arguments))
+         (sql (format nil "INSERT INTO ~A (job_name, arguments, status, attempts, max_attempts, available_at, last_error, created_at, updated_at) VALUES (?, ?, 'pending', 0, ?, ?, NULL, ?, ?)"
+                     *jobs-table-name*)))
+    (with-db-connection (connection)
+      (dbi-cp:execute (dbi-cp:prepare connection sql)
+                      (list (job-name->db-string job-name)
+                            arguments-json
+                            resolved-max-attempts
+                            available-at
+                            now-string
+                            now-string))
+      (let ((id (get-last-id-impl *database-type* connection)))
+        (log.job "Job enqueued" :job-name job-name :job-id id :available-at available-at)
+        id))))
+
+
+;;;; ----------------------------------------
+;;;; claim (pessimistic-locking select)
+
+(defun select-for-update-clause ()
+  "Lock clause appended to the claim SELECT for backends with row-level
+   locking. Mirrors the modes documented for
+   clails/model/lock:with-locked-transaction. SQLite3 has no row-level lock;
+   it is handled instead by running the claim inside a BEGIN IMMEDIATE
+   transaction (see claim-due-job)."
+  (cond
+    ((typep *database-type* '<database-type-mysql>) "FOR UPDATE SKIP LOCKED")
+    ((typep *database-type* '<database-type-postgresql>) "FOR UPDATE SKIP LOCKED")
+    (t nil)))
+
+(defun claim-due-job ()
+  "Atomically claim the single most-overdue pending job, if any.
+
+   Runs a SELECT ... FOR UPDATE SKIP LOCKED (MySQL/PostgreSQL) or a claim
+   inside a BEGIN IMMEDIATE transaction (SQLite3) followed by an UPDATE that
+   marks the row :running and increments its attempt count, all within one
+   transaction, so that concurrent workers never claim the same row.
+
+   @return [plist or nil] The claimed job (see row->job-plist), or nil if no
+                          job is currently due
+   "
+  (flet ((do-claim ()
+           (let* ((connection (get-connection))
+                  (now-string (ut->db-string (get-universal-time)))
+                  (lock-clause (select-for-update-clause))
+                  (select-sql (format nil "SELECT * FROM ~A WHERE status = 'pending' AND available_at <= ? ORDER BY available_at ASC, id ASC LIMIT 1~@[ ~A~]"
+                                      *jobs-table-name* lock-clause))
+                  (row (dbi-cp:fetch (dbi-cp:execute (dbi-cp:prepare connection select-sql)
+                                                     (list now-string)))))
+             (when row
+               (let ((id (getf row :|id|)))
+                 (dbi-cp:execute
+                  (dbi-cp:prepare connection
+                                  (format nil "UPDATE ~A SET status = 'running', attempts = attempts + 1, updated_at = ? WHERE id = ?"
+                                          *jobs-table-name*))
+                  (list now-string id))
+                 ;; Reflect the attempt increment we just performed without a
+                 ;; second round-trip.
+                 (incf (getf row :|attempts|))
+                 (let ((job (row->job-plist row)))
+                   (log.job "Job claimed" :job-name (job-plist-job-name job) :job-id id
+                            :attempt (job-plist-attempts job))
+                   job))))))
+    (if (typep *database-type* '<database-type-sqlite3>)
+        (let ((*sqlite3-transaction-mode* :immediate))
+          (with-transaction (do-claim)))
+        (with-transaction (do-claim)))))
+
+
+;;;; ----------------------------------------
+;;;; finalize
+
+(defun mark-job-succeeded (job-id)
+  "Mark a claimed job as :succeeded.
+
+   @param job-id [integer] id of the job row
+   @return [null]
+   "
+  (with-transaction
+    (dbi-cp:execute
+     (dbi-cp:prepare (get-connection)
+                     (format nil "UPDATE ~A SET status = 'succeeded', last_error = NULL, updated_at = ? WHERE id = ?"
+                             *jobs-table-name*))
+     (list (ut->db-string (get-universal-time)) job-id)))
+  (log.job "Job succeeded" :job-id job-id)
+  nil)
+
+(defun backoff-seconds (attempt-number &key (base *default-backoff-base-seconds*)
+                                            (max *default-backoff-max-seconds*))
+  "Compute the exponential backoff delay, in seconds, before retrying after
+   the ATTEMPT-NUMBERth attempt has failed.
+
+   @param attempt-number [integer] 1-based attempt number that just failed
+   @param base [integer] Base delay in seconds
+   @param max [integer] Upper bound on the delay in seconds
+   @return [integer] Delay in seconds
+   "
+  (min max (* base (expt 2 (max 0 (1- attempt-number))))))
+
+(defun mark-job-retry (job-id attempt-number error-message)
+  "Reschedule a failed job for a later retry using exponential backoff.
+
+   @param job-id [integer] id of the job row
+   @param attempt-number [integer] 1-based attempt number that just failed
+   @param error-message [string] Error message to record
+   @return [null]
+   "
+  (let* ((delay (backoff-seconds attempt-number))
+         (now (get-universal-time))
+         (available-at (ut->db-string (+ now delay))))
+    (with-transaction
+      (dbi-cp:execute
+       (dbi-cp:prepare (get-connection)
+                       (format nil "UPDATE ~A SET status = 'pending', available_at = ?, last_error = ?, updated_at = ? WHERE id = ?"
+                               *jobs-table-name*))
+       (list available-at error-message (ut->db-string now) job-id)))
+    (log.job "Job failed, will retry" :job-id job-id :attempt attempt-number
+             :retry-in-seconds delay :error error-message))
+  nil)
+
+(defun mark-job-failed (job-id error-message)
+  "Mark a job as permanently :failed (no further retries).
+
+   @param job-id [integer] id of the job row
+   @param error-message [string] Error message to record
+   @return [null]
+   "
+  (with-transaction
+    (dbi-cp:execute
+     (dbi-cp:prepare (get-connection)
+                     (format nil "UPDATE ~A SET status = 'failed', last_error = ?, updated_at = ? WHERE id = ?"
+                             *jobs-table-name*))
+     (list error-message (ut->db-string (get-universal-time)) job-id)))
+  (log.job "Job failed permanently" :job-id job-id :error error-message)
+  nil)

--- a/src/job/registry.lisp
+++ b/src/job/registry.lisp
@@ -1,0 +1,119 @@
+;;;; Job Registry
+;;;; Central registry for job registration and lookup.
+;;;;
+;;;; This mirrors clails/task/registry, but jobs are keyed by name only
+;;;; (no namespaces) since jobs are executed asynchronously by the worker
+;;;; rather than invoked ad-hoc from the CLI.
+
+(defpackage #:clails/job/registry
+  (:use #:cl)
+  (:export #:register-job
+           #:find-job
+           #:list-jobs
+           #:job-exists-p
+           #:remove-job
+           #:clear-registry
+           #:make-job-info
+           #:job-info-name
+           #:job-info-description
+           #:job-info-max-attempts
+           #:job-info-function))
+
+(in-package #:clails/job/registry)
+
+(defvar *job-registry* (make-hash-table :test 'eq)
+  "Global job registry. Key is the job name keyword.")
+
+(defclass <job-info> ()
+  ((name
+    :initarg :name
+    :accessor job-info-name
+    :documentation "Job name (keyword)")
+   (description
+    :initarg :description
+    :initform nil
+    :accessor job-info-description
+    :documentation "Job description")
+   (max-attempts
+    :initarg :max-attempts
+    :initform 25
+    :accessor job-info-max-attempts
+    :documentation "Default maximum attempts before a job is marked failed")
+   (function
+    :initarg :function
+    :accessor job-info-function
+    :documentation "Job handler function"))
+  (:documentation "Information about a registered job."))
+
+(defun make-job-info (&key name description (max-attempts 25) function)
+  "Create a new job-info instance.
+
+   @param name [keyword] Job name
+   @param description [string or nil] Job description (optional)
+   @param max-attempts [integer] Default maximum attempts (default: 25)
+   @param function [function] Job handler function
+   @return [<job-info>] Job information object
+   "
+  (make-instance '<job-info>
+                 :name name
+                 :description description
+                 :max-attempts max-attempts
+                 :function function))
+
+(defun register-job (name &key description (max-attempts 25) function)
+  "Register a job handler in the global registry.
+
+   @param name [keyword] Job name
+   @param description [string or nil] Job description (optional)
+   @param max-attempts [integer] Default maximum attempts (default: 25)
+   @param function [function] Job handler function
+   @return [keyword] The registered job name
+   "
+  (setf (gethash name *job-registry*)
+        (make-job-info :name name
+                       :description description
+                       :max-attempts max-attempts
+                       :function function))
+  name)
+
+(defun find-job (name)
+  "Find a job by name.
+
+   @param name [keyword] Job name
+   @return [<job-info> or nil] Job information if found, nil otherwise
+   "
+  (gethash name *job-registry*))
+
+(defun job-exists-p (name)
+  "Check if a job is registered.
+
+   @param name [keyword] Job name
+   @return [boolean] T if the job exists, nil otherwise
+   "
+  (not (null (find-job name))))
+
+(defun list-jobs ()
+  "List all registered jobs.
+
+   @return [list] List of (name . job-info) pairs sorted by name
+   "
+  (let ((jobs '()))
+    (maphash (lambda (name job-info)
+               (push (cons name job-info) jobs))
+             *job-registry*)
+    (sort jobs #'string< :key (lambda (pair) (string (car pair))))))
+
+(defun remove-job (name)
+  "Remove a job from the registry.
+
+   @param name [keyword] Job name
+   @return [boolean] T if the job was removed, nil if not found
+   "
+  (remhash name *job-registry*))
+
+(defun clear-registry ()
+  "Clear all jobs from the registry.
+
+   @return [null] Always returns nil
+   "
+  (clrhash *job-registry*))

--- a/src/job/worker.lisp
+++ b/src/job/worker.lisp
@@ -1,0 +1,149 @@
+;;;; Job Worker
+;;;; Polls the job queue table and runs due jobs, with retry/backoff.
+
+(defpackage #:clails/job/worker
+  (:use #:cl)
+  (:import-from #:clails/job/registry
+                #:find-job
+                #:job-info-function)
+  (:import-from #:clails/job/queue
+                #:claim-due-job
+                #:mark-job-succeeded
+                #:mark-job-retry
+                #:mark-job-failed
+                #:job-plist-id
+                #:job-plist-job-name
+                #:job-plist-arguments
+                #:job-plist-attempts
+                #:job-plist-max-attempts)
+  (:import-from #:clails/logger/core
+                #:log.job)
+  (:export #:run-worker-tick
+           #:run-worker-loop
+           #:start-worker
+           #:stop-worker
+           #:worker-running-p))
+
+(in-package #:clails/job/worker)
+
+(defvar *worker-thread* nil
+  "The bordeaux-threads thread started by start-worker, or nil if the worker
+   is not running as a background thread.")
+
+(defvar *worker-stop-requested* nil
+  "When T, run-worker-loop exits at the start of its next iteration.")
+
+(defun process-claimed-job (job)
+  "Run the handler for a claimed job and record the outcome.
+
+   Looks the job's handler up in the job registry by name and applies it to
+   the job's stored arguments. On success the job is marked :succeeded. On
+   error, the job is rescheduled with exponential backoff (see
+   clails/job/queue:backoff-seconds) if it has not yet reached its
+   max-attempts, or marked :failed (with the error message recorded)
+   otherwise. A job whose name is not registered in this process is treated
+   the same as a handler error, using the same retry/backoff bookkeeping, so
+   that a worker started before the job's defjob is loaded still gets a
+   chance to retry once it is.
+
+   @param job [plist] Claimed job, as returned by clails/job/queue:claim-due-job
+   @return [keyword] One of :succeeded, :retrying, :failed
+   "
+  (let* ((job-id (job-plist-id job))
+         (job-name (job-plist-job-name job))
+         (arguments (job-plist-arguments job))
+         (attempts (job-plist-attempts job))
+         (max-attempts (job-plist-max-attempts job))
+         (job-info (find-job job-name)))
+    (handler-case
+        (progn
+          (unless job-info
+            (error "No job registered for name ~A" job-name))
+          (apply (job-info-function job-info) arguments)
+          (mark-job-succeeded job-id)
+          :succeeded)
+      (error (e)
+        (let ((error-message (format nil "~A" e)))
+          (if (>= attempts max-attempts)
+              (progn
+                (mark-job-failed job-id error-message)
+                :failed)
+              (progn
+                (mark-job-retry job-id attempts error-message)
+                :retrying)))))))
+
+(defun run-worker-tick ()
+  "Claim and run at most one due job.
+
+   @return [keyword] :ran if a job was claimed and processed (regardless of
+                     whether it ultimately succeeded, was rescheduled, or
+                     failed), :idle if no job was currently due
+   "
+  (let ((job (claim-due-job)))
+    (if job
+        (progn (process-claimed-job job) :ran)
+        :idle)))
+
+(defun run-worker-loop (&key max-iterations (poll-interval 1))
+  "Repeatedly claim and run due jobs until stopped.
+
+   Runs run-worker-tick in a loop. Whenever a tick finds no due job (:idle),
+   sleeps for poll-interval seconds before polling again. Intended to be run
+   either directly (e.g. from the CLI 'job:work' command, or a bounded
+   number of iterations in a test) or on a background thread via
+   start-worker.
+
+   @param max-iterations [integer or nil] Stop after this many ticks; nil
+                                          (the default) loops forever, until
+                                          stop-worker sets
+                                          *worker-stop-requested*. Tests
+                                          should always pass a small
+                                          max-iterations rather than relying
+                                          on stop-worker, to keep test runs
+                                          bounded.
+   @param poll-interval [number] Seconds to sleep between ticks that found no
+                                 due job (default: 1)
+   @return [null]
+   "
+  (loop for i from 0
+        while (or (null max-iterations) (< i max-iterations))
+        while (not *worker-stop-requested*)
+        do (let ((result (run-worker-tick)))
+             (when (eq result :idle)
+               (sleep poll-interval))))
+  nil)
+
+(defun worker-running-p ()
+  "@return [boolean] T if a worker thread started by start-worker is alive"
+  (and *worker-thread*
+       (bt:thread-alive-p *worker-thread*)))
+
+(defun start-worker (&key (poll-interval 1))
+  "Start the job worker on its own background thread.
+
+   Uses the same connection-pool-per-thread model as the rest of clails
+   (see clails/model/connection): the worker thread lazily acquires its own
+   pooled connection the first time it claims or finalizes a job.
+
+   @param poll-interval [number] Seconds to sleep between polls that found no
+                                 due job (default: 1)
+   @return [t] the started thread
+   "
+  (setf *worker-stop-requested* nil)
+  (setf *worker-thread*
+        (bt:make-thread (lambda () (run-worker-loop :poll-interval poll-interval))
+                        :name "clails-job-worker"))
+  (log.job "Job worker started" :poll-interval poll-interval)
+  *worker-thread*)
+
+(defun stop-worker ()
+  "Signal the background worker thread to stop and wait for it to exit.
+
+   @return [null]
+   "
+  (setf *worker-stop-requested* t)
+  (when *worker-thread*
+    (bt:join-thread *worker-thread*)
+    (setf *worker-thread* nil)
+    (log.job "Job worker stopped"))
+  nil)

--- a/src/logger/core.lisp
+++ b/src/logger/core.lisp
@@ -19,6 +19,7 @@
            #:log.web-access
            #:log.audit
            #:log.task
+           #:log.job
            #:set-logger-level
            #:add-appender
            #:clear-loggers
@@ -395,6 +396,19 @@
      (log.task \"Task completed\" :task-name \"cleanup\" :duration 1.234 :status :success)
    "
   `(clails/logger/core::log-message-to :task :info ,message ,@context))
+
+(defmacro log.job (message &rest context)
+  "Log a background job event to the :job logger with :info level.
+
+   Used for logging job enqueue, claim, retry, and completion events.
+
+   @param message [string] Job event message
+   @param context [plist] Additional context (e.g., :job-name, :job-id, :attempts, :status)
+   @example
+     (log.job \"Job enqueued\" :job-name :send-email :job-id 1)
+     (log.job \"Job failed\" :job-name :send-email :job-id 1 :attempts 3 :status :failed)
+   "
+  `(clails/logger/core::log-message-to :job :info ,message ,@context))
 
 ;;; ------------------------------------------------------------------
 ;;; Log Level Check API

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -18,6 +18,7 @@
   (:import-from #:clails/logger)
   (:import-from #:clails/datetime)
   (:import-from #:clails/task)
+  (:import-from #:clails/job)
   (:export #:create-project
            #:generate/model
            #:generate/migration

--- a/src/project/generate.lisp
+++ b/src/project/generate.lisp
@@ -6,6 +6,7 @@
                 #:*project-dir*)
   (:export #:gen/model
            #:gen/migration
+           #:gen/job-queue-migration
            #:gen/view
            #:gen/controller
            #:gen/scaffold
@@ -218,6 +219,25 @@
   (let* ((unique-name (gen-unique-name migration-name))
          (filename (format nil "~A.lisp" unique-name)))
     (gen/template unique-name filename "/db/migrate/" "template/generate/migration.lisp.tmpl" overwrite)))
+
+(defun gen/job-queue-migration (&key (overwrite T))
+  "Generate the framework-provided migration that creates the clails_jobs
+   table backing the DB-persisted job queue (see clails/job:enqueue-job and
+   document/job-queue.md).
+
+   Generates a migration file the same way 'clails generate:migration' does
+   (unique timestamp prefix, under db/migrate/), just pre-filled with the
+   clails_jobs table definition instead of an empty skeleton, so the table
+   is created and rolled back through the normal db:migrate/db:rollback
+   flow like any other migration.
+
+   @param overwrite [boolean] Whether to overwrite existing file
+   @return [t]
+   "
+  (let* ((migration-name "create-clails-jobs-table")
+         (unique-name (gen-unique-name migration-name))
+         (filename (format nil "~A.lisp" unique-name)))
+    (gen/template unique-name filename "/db/migrate/" "template/generate/job-queue-migration.lisp.tmpl" overwrite)))
 
 
 ;; ----------------------------------------

--- a/template/generate/job-queue-migration.lisp.tmpl
+++ b/template/generate/job-queue-migration.lisp.tmpl
@@ -1,0 +1,30 @@
+; -*- mode: lisp -*-
+(in-package #:<%= (@ project-name ) %>-db)
+
+;; Creates the table backing clails' DB-persisted job queue
+;; (clails/job:enqueue-job / clails/job/worker). See document/job-queue.md.
+(defmigration "<%= (@ name ) %>"
+  (:up #'(lambda (connection)
+           (create-table connection :table "clails_jobs"
+                                    :columns '(("job-name" :type :string
+                                                          :not-null T)
+                                               ("arguments" :type :text
+                                                           :not-null T)
+                                               ("status" :type :string
+                                                        :not-null T
+                                                        :default-value "pending")
+                                               ("attempts" :type :integer
+                                                          :not-null T
+                                                          :default-value 0)
+                                               ("max-attempts" :type :integer
+                                                              :not-null T
+                                                              :default-value 25)
+                                               ("available-at" :type :datetime
+                                                              :not-null T)
+                                               ("last-error" :type :text
+                                                            :not-null NIL)))
+           (add-index connection :table "clails_jobs"
+                                 :index "idx-clails-jobs-status-available-at"
+                                 :columns '("status" "available-at")))
+   :down #'(lambda (connection)
+             (drop-table connection :table "clails_jobs"))))

--- a/test/data/0014-job-queue-test/db/migrate/20250101-000000-create-clails-jobs-table.lisp
+++ b/test/data/0014-job-queue-test/db/migrate/20250101-000000-create-clails-jobs-table.lisp
@@ -1,0 +1,27 @@
+(in-package #:clails-test/job/db)
+
+(defmigration "20250101-000000-create-clails-jobs-table"
+ (:up #'(lambda (connection)
+          (create-table connection :table "clails_jobs"
+                                   :columns '(("job-name" :type :string
+                                                         :not-null T)
+                                              ("arguments" :type :text
+                                                          :not-null T)
+                                              ("status" :type :string
+                                                       :not-null T
+                                                       :default-value "pending")
+                                              ("attempts" :type :integer
+                                                         :not-null T
+                                                         :default-value 0)
+                                              ("max-attempts" :type :integer
+                                                             :not-null T
+                                                             :default-value 25)
+                                              ("available-at" :type :datetime
+                                                             :not-null T)
+                                              ("last-error" :type :text
+                                                           :not-null NIL)))
+          (add-index connection :table "clails_jobs"
+                                :index "idx-clails-jobs-status-available-at"
+                                :columns '("status" "available-at")))
+  :down #'(lambda (connection)
+            (drop-table connection :table "clails_jobs"))))

--- a/test/job/core.lisp
+++ b/test/job/core.lisp
@@ -1,0 +1,31 @@
+;;;; Test for Job Core (defjob)
+
+(defpackage #:clails-test/job/core
+  (:use #:cl
+        #:rove
+        #:clails/job))
+
+(in-package #:clails-test/job/core)
+
+(deftest test-defjob-registers-job
+  (testing "defjob registers a job with the given name and options"
+    (clear-registry)
+
+    (defjob :greet
+      :description "Print a greeting"
+      :max-attempts 3
+      :function (lambda (&key name) (format nil "Hello, ~A!" name)))
+
+    (let ((job (find-job :greet)))
+      (ok job)
+      (ok (eq :greet (job-info-name job)))
+      (ok (string= "Print a greeting" (job-info-description job)))
+      (ok (= 3 (job-info-max-attempts job)))
+      (ok (string= "Hello, World!" (funcall (job-info-function job) :name "World"))))))
+
+(deftest test-defjob-default-max-attempts
+  (testing "defjob without :max-attempts defaults to 25"
+    (clear-registry)
+
+    (defjob :no-options :function (lambda ()))
+    (ok (= 25 (job-info-max-attempts (find-job :no-options))))))

--- a/test/job/queue.lisp
+++ b/test/job/queue.lisp
@@ -1,0 +1,215 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/job/queue
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:with-db-connection-direct)
+  (:import-from #:clails/model/migration
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/job
+                #:enqueue-job
+                #:claim-due-job
+                #:mark-job-succeeded
+                #:mark-job-retry
+                #:mark-job-failed
+                #:backoff-seconds
+                #:job-plist-id
+                #:job-plist-job-name
+                #:job-plist-arguments
+                #:job-plist-attempts
+                #:job-plist-max-attempts
+                #:register-job
+                #:clear-registry))
+
+(defpackage #:clails-test/job/db
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-column
+                #:add-index
+                #:drop-table
+                #:drop-column
+                #:drop-index))
+
+(in-package #:clails-test/job/queue)
+
+
+(setup
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0014" "/app/test/data/0014-job-queue-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (db-create)
+  (db-migrate)
+  (startup-connection-pool))
+
+(teardown
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (shutdown-connection-pool))
+
+
+;;; Helper: rove only calls setup/teardown once per file, so each deftest
+;;; clears the table (and job registry) itself.
+
+(defun clean-jobs-table ()
+  (with-db-connection-direct (connection)
+    (dbi:do-sql connection "delete from clails_jobs")))
+
+(defun text-value (value)
+  "MySQL hands TEXT column values back as octet vectors, not strings."
+  (typecase value
+    ((vector (unsigned-byte 8)) (babel:octets-to-string value))
+    (t value)))
+
+
+(deftest enqueue-job-test
+  (testing "enqueue-job persists a pending row with the given arguments"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((id (enqueue-job :send-email :arguments (list :to "a@example.com" :subject "Hi"))))
+      (ok (integerp id))
+
+      (let ((job (claim-due-job)))
+        (ok job)
+        (ok (= id (job-plist-id job)))
+        (ok (eq :send-email (job-plist-job-name job)))
+        ;; arguments round-trip through JSON, which doesn't guarantee key
+        ;; order, so compare values rather than list identity
+        (ok (string= "a@example.com" (getf (job-plist-arguments job) :to)))
+        (ok (string= "Hi" (getf (job-plist-arguments job) :subject)))
+        (ok (= 1 (job-plist-attempts job)))
+        (ok (= 25 (job-plist-max-attempts job)))))))
+
+(deftest enqueue-job-uses-registered-max-attempts-test
+  (testing "enqueue-job defaults :max-attempts to the job's registered default"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (register-job :limited-job :max-attempts 4 :function (lambda ()))
+    (enqueue-job :limited-job)
+
+    (let ((job (claim-due-job)))
+      (ok (= 4 (job-plist-max-attempts job))))))
+
+(deftest enqueue-job-explicit-max-attempts-overrides-test
+  (testing "enqueue-job :max-attempts overrides the job's registered default"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (register-job :limited-job :max-attempts 4 :function (lambda ()))
+    (enqueue-job :limited-job :max-attempts 9)
+
+    (let ((job (claim-due-job)))
+      (ok (= 9 (job-plist-max-attempts job))))))
+
+(deftest claim-due-job-skips-future-jobs-test
+  (testing "claim-due-job does not claim a job scheduled in the future"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (enqueue-job :future-job :run-at (+ (get-universal-time) 3600))
+
+    (ok (null (claim-due-job)))))
+
+(deftest claim-due-job-skips-already-running-jobs-test
+  (testing "claim-due-job does not re-claim a job that is already running"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (enqueue-job :one-job)
+    (let ((first-claim (claim-due-job)))
+      (ok first-claim))
+
+    (ok (null (claim-due-job)))))
+
+(deftest claim-due-job-orders-by-available-at-test
+  (testing "claim-due-job claims the most-overdue job first"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((later-id (enqueue-job :later-job :run-at (- (get-universal-time) 10)))
+          (earlier-id (enqueue-job :earlier-job :run-at (- (get-universal-time) 100))))
+      (declare (ignore later-id))
+
+      (let ((job (claim-due-job)))
+        (ok (= earlier-id (job-plist-id job)))))))
+
+(deftest mark-job-succeeded-test
+  (testing "mark-job-succeeded transitions a claimed job to succeeded"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (enqueue-job :ok-job)
+    (let* ((job (claim-due-job))
+           (id (job-plist-id job)))
+      (mark-job-succeeded id)
+
+      (with-db-connection-direct (connection)
+        (let ((row (dbi:fetch (dbi:execute (dbi:prepare connection "select status from clails_jobs where id = ?")
+                                           (list id)))))
+          (ok (string= "succeeded" (getf row :|status|))))))))
+
+(deftest mark-job-retry-reschedules-with-backoff-test
+  (testing "mark-job-retry sets status back to pending, records the error, and delays available_at"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (enqueue-job :flaky-job)
+    (let* ((job (claim-due-job))
+           (id (job-plist-id job))
+           (before (get-universal-time)))
+      (mark-job-retry id 1 "boom")
+
+      (with-db-connection-direct (connection)
+        (let ((row (dbi:fetch (dbi:execute (dbi:prepare connection "select status, last_error, available_at from clails_jobs where id = ?")
+                                           (list id)))))
+          (ok (string= "pending" (getf row :|status|)))
+          (ok (string= "boom" (text-value (getf row :|last_error|))))
+          ;; available_at should have moved into the future by roughly
+          ;; backoff-seconds(1), i.e. *default-backoff-base-seconds*
+          (ok (>= (getf row :|available_at|)
+                  (+ before clails/job:*default-backoff-base-seconds*)))
+          (ok (< (getf row :|available_at|)
+                 (+ before clails/job:*default-backoff-base-seconds* 10)))))
+
+      ;; the retried job should not be immediately re-claimable
+      (ok (null (claim-due-job))))))
+
+(deftest mark-job-failed-test
+  (testing "mark-job-failed marks the job permanently failed with the error recorded"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (enqueue-job :doomed-job)
+    (let* ((job (claim-due-job))
+           (id (job-plist-id job)))
+      (mark-job-failed id "fatal error")
+
+      (with-db-connection-direct (connection)
+        (let ((row (dbi:fetch (dbi:execute (dbi:prepare connection "select status, last_error from clails_jobs where id = ?")
+                                           (list id)))))
+          (ok (string= "failed" (getf row :|status|)))
+          (ok (string= "fatal error" (text-value (getf row :|last_error|))))))
+
+      (ok (null (claim-due-job))))))
+
+(deftest backoff-seconds-grows-exponentially-and-is-capped-test
+  (testing "backoff-seconds doubles per attempt and is capped at the configured max"
+    (ok (= clails/job:*default-backoff-base-seconds* (backoff-seconds 1)))
+    (ok (= (* 2 clails/job:*default-backoff-base-seconds*) (backoff-seconds 2)))
+    (ok (= (* 4 clails/job:*default-backoff-base-seconds*) (backoff-seconds 3)))
+    (ok (<= (backoff-seconds 100) clails/job:*default-backoff-max-seconds*))))

--- a/test/job/registry.lisp
+++ b/test/job/registry.lisp
@@ -1,0 +1,71 @@
+;;;; Test for Job Registry
+
+(defpackage #:clails-test/job/registry
+  (:use #:cl
+        #:rove
+        #:clails/job))
+
+(in-package #:clails-test/job/registry)
+
+(deftest test-register-and-find-job
+  (testing "Register a job and find it"
+    (clear-registry)
+
+    (let ((key (register-job :send-email
+                             :description "Send an email"
+                             :max-attempts 7
+                             :function (lambda (&key to) (declare (ignore to))))))
+      (ok (eq :send-email key))
+
+      (let ((job (find-job :send-email)))
+        (ok job)
+        (ok (eq :send-email (job-info-name job)))
+        (ok (string= "Send an email" (job-info-description job)))
+        (ok (= 7 (job-info-max-attempts job)))))))
+
+(deftest test-register-job-default-max-attempts
+  (testing "Registering a job without :max-attempts defaults to 25"
+    (clear-registry)
+
+    (register-job :some-job :function (lambda ()))
+    (ok (= 25 (job-info-max-attempts (find-job :some-job))))))
+
+(deftest test-job-exists-p
+  (testing "Check if job exists"
+    (clear-registry)
+
+    (register-job :foo :function (lambda () nil))
+
+    (ok (job-exists-p :foo))
+    (ok (not (job-exists-p :nonexistent)))))
+
+(deftest test-list-jobs
+  (testing "List all jobs"
+    (clear-registry)
+
+    (register-job :job1 :function (lambda () nil))
+    (register-job :job2 :function (lambda () nil))
+    (register-job :job3 :function (lambda () nil))
+
+    (ok (= 3 (length (list-jobs))))))
+
+(deftest test-remove-job
+  (testing "Remove a job"
+    (clear-registry)
+
+    (register-job :to-remove :function (lambda () nil))
+    (ok (job-exists-p :to-remove))
+
+    (remove-job :to-remove)
+    (ok (not (job-exists-p :to-remove)))))
+
+(deftest test-clear-registry
+  (testing "Clear all jobs"
+    (clear-registry)
+
+    (register-job :job1 :function (lambda () nil))
+    (register-job :job2 :function (lambda () nil))
+    (ok (= 2 (length (list-jobs))))
+
+    (clear-registry)
+    (ok (= 0 (length (list-jobs))))))

--- a/test/job/worker.lisp
+++ b/test/job/worker.lisp
@@ -1,0 +1,165 @@
+(in-package #:cl-user)
+(defpackage #:clails-test/job/worker
+  (:use #:cl
+        #:rove)
+  (:import-from #:clails/util
+                #:env-or-default)
+  (:import-from #:clails/model/connection
+                #:startup-connection-pool
+                #:shutdown-connection-pool
+                #:with-db-connection-direct)
+  (:import-from #:clails/model/migration
+                #:db-create
+                #:db-migrate)
+  (:import-from #:clails/job
+                #:enqueue-job
+                #:defjob
+                #:register-job
+                #:clear-registry
+                #:run-worker-loop
+                #:run-worker-tick))
+
+;;; Redeclared independently in each test file that migrates the clails_jobs
+;;; table (this mirrors test/model/connection.lisp and
+;;; test/model/migration.lisp both independently declaring
+;;; clails-test/model/db): package-inferred-system loads each test file as
+;;; its own component, so the package the migration file (in
+;;; test/data/0014-job-queue-test/db/migrate/) is loaded into must already
+;;; exist regardless of which of these test files runs first.
+(defpackage #:clails-test/job/db
+  (:use #:cl)
+  (:import-from #:clails/model/migration
+                #:defmigration
+                #:create-table
+                #:add-column
+                #:add-index
+                #:drop-table
+                #:drop-column
+                #:drop-index))
+
+(in-package #:clails-test/job/worker)
+
+
+(setup
+  (setf clails/environment:*database-type* (make-instance 'clails/environment::<database-type-mysql>))
+  (setf clails/environment:*project-environment* :test)
+  (setf clails/environment:*database-config* `(:test (:database-name ,(env-or-default "CLAILS_MYSQL_DATABASE" "clails_test")
+                                                      :username ,(env-or-default "CLAILS_MYSQL_USERNAME" "root")
+                                                      :password ,(env-or-default "CLAILS_MYSQL_PASSWORD" "password")
+                                                      :host ,(env-or-default "CLAILS_MYSQL_HOST" "mysql-test")
+                                                      :port ,(env-or-default "CLAILS_MYSQL_PORT" "3306"))))
+  (setf clails/environment:*migration-base-dir* (env-or-default "CLAILS_MIGRATION_DIR_0014" "/app/test/data/0014-job-queue-test"))
+  (uiop:setup-temporary-directory)
+  (ensure-directories-exist (merge-pathnames "db/" uiop:*temporary-directory*))
+  (setf clails/environment::*project-dir* uiop:*temporary-directory*)
+  (db-create)
+  (db-migrate)
+  (startup-connection-pool))
+
+(teardown
+  (uiop:delete-directory-tree uiop:*temporary-directory* :if-does-not-exist :ignore :validate t)
+  (shutdown-connection-pool))
+
+
+;;; rove only calls setup/teardown once per file, so each deftest cleans up
+;;; after itself.
+
+(defun clean-jobs-table ()
+  (with-db-connection-direct (connection)
+    (dbi:do-sql connection "delete from clails_jobs")))
+
+(defun text-value (value)
+  "MySQL hands TEXT column values back as octet vectors, not strings."
+  (typecase value
+    ((vector (unsigned-byte 8)) (babel:octets-to-string value))
+    (t value)))
+
+(defun job-row (id)
+  (with-db-connection-direct (connection)
+    (dbi:fetch (dbi:execute (dbi:prepare connection
+                                        "select status, attempts, last_error from clails_jobs where id = ?")
+                            (list id)))))
+
+
+(deftest worker-runs-a-successful-job-test
+  (testing "run-worker-loop claims and successfully runs a due job"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((seen nil))
+      (defjob :say-hello
+        :function (lambda (&key name) (setf seen name)))
+
+      (let ((id (enqueue-job :say-hello :arguments (list :name "clails"))))
+        (run-worker-loop :max-iterations 5 :poll-interval 0.05)
+
+        (ok (string= "clails" seen))
+        (let ((row (job-row id)))
+          (ok (string= "succeeded" (getf row :|status|)))
+          (ok (= 1 (getf row :|attempts|))))))))
+
+(deftest worker-retries-then-succeeds-test
+  (testing "a job that fails twice then succeeds ends up succeeded, having retried with backoff"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((clails/job:*default-backoff-base-seconds* 0)
+          (attempt-count 0))
+      (defjob :flaky
+        :max-attempts 5
+        :function (lambda ()
+                    (incf attempt-count)
+                    (when (< attempt-count 3)
+                      (error "still flaky (attempt ~A)" attempt-count))
+                    :done))
+
+      (let ((id (enqueue-job :flaky)))
+        (run-worker-loop :max-iterations 20 :poll-interval 0.05)
+
+        (ok (= 3 attempt-count))
+        (let ((row (job-row id)))
+          (ok (string= "succeeded" (getf row :|status|)))
+          (ok (= 3 (getf row :|attempts|))))))))
+
+(deftest worker-fails-permanently-after-max-attempts-test
+  (testing "a job that always fails is marked failed once max-attempts is reached, with the error recorded"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((clails/job:*default-backoff-base-seconds* 0)
+          (attempt-count 0))
+      (defjob :always-broken
+        :max-attempts 3
+        :function (lambda ()
+                    (incf attempt-count)
+                    (error "boom ~A" attempt-count)))
+
+      (let ((id (enqueue-job :always-broken)))
+        (run-worker-loop :max-iterations 20 :poll-interval 0.05)
+
+        (ok (= 3 attempt-count))
+        (let ((row (job-row id)))
+          (ok (string= "failed" (getf row :|status|)))
+          (ok (= 3 (getf row :|attempts|)))
+          (ok (search "boom 3" (text-value (getf row :|last_error|)))))))))
+
+(deftest worker-tick-is-idle-when-nothing-due-test
+  (testing "run-worker-tick returns :idle when there is no due job"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (ok (eq :idle (run-worker-tick)))))
+
+(deftest worker-handles-unregistered-job-name-test
+  (testing "a job whose name is not (yet) registered is retried like any other failure, then fails permanently"
+    (clean-jobs-table)
+    (clear-registry)
+
+    (let ((clails/job:*default-backoff-base-seconds* 0))
+      (let ((id (enqueue-job :nobody-home :max-attempts 2)))
+        (run-worker-loop :max-iterations 10 :poll-interval 0.05)
+
+        (let ((row (job-row id)))
+          (ok (string= "failed" (getf row :|status|)))
+          (ok (= 2 (getf row :|attempts|)))
+          (ok (search "No job registered" (text-value (getf row :|last_error|)))))))))


### PR DESCRIPTION
Closes #167

## Summary

Adds a DB-persisted background job queue -- an asynchronous sibling to the
existing synchronous task system (`deftask`/`run-task`).

- `defjob` registers a job handler (mirrors `deftask`'s ergonomics).
- `enqueue-job` persists a job (name, JSON-encoded arguments, status,
  attempts/max-attempts, `available_at` for scheduling, `last_error`) to a
  new `clails_jobs` table.
- A worker (`run-worker-loop`/`start-worker`/`stop-worker`, or the CLI's
  `clails job:work`) polls the table, claims due jobs, runs them, and
  records the outcome.
- Claiming a job is done inside one transaction using the same
  pessimistic-locking primitives already documented for
  `with-locked-transaction`: `SELECT ... FOR UPDATE SKIP LOCKED` on
  MySQL/PostgreSQL, a `BEGIN IMMEDIATE` transaction (the same mechanism the
  SQLite3 lock module provides) on SQLite3. This is what makes it safe to
  run more than one worker against the table.
- A job whose handler errors is retried with exponential backoff
  (`*default-backoff-base-seconds*`, doubling per attempt, capped at
  `*default-backoff-max-seconds*`) until it either succeeds or exhausts its
  `max-attempts`, at which point it's marked `:failed` with the error
  recorded in `last_error`.
- `clails generate:job-queue-setup` generates the `clails_jobs` migration
  through the normal `generate:migration`/`db:migrate` flow (no new
  migration mechanism).

### Why raw SQL instead of a `defmodel`-backed model

`defmodel`'s column introspection runs for *every* registered model at
`initialize-table-information` (server/worker/console boot), so a
framework-provided model for `clails_jobs` would force every clails
application to have that table just to start up. Talking to the table with
plain SQL -- the same approach `clails/model/migration` already uses for its
own `migration` bookkeeping table -- keeps the job queue fully opt-in:
nothing breaks until an application actually calls `enqueue-job`/runs a
worker.

### In scope

- Persisting a job, worker claim/run loop, exponential backoff retries up to
  `max-attempts`, running a job at/after a given time (`:run-at`).

### Explicitly out of scope (see `document/job-queue.md`'s "Future
Directions" section for details)

- **External broker integration** (Redis/Sidekiq, RabbitMQ, SQS, ...) --
  noted as a future option requiring a new dependency, not implemented here.
- **A web dashboard** for inspecting jobs.
- **Cron-style recurring schedules** -- only "run once, at/after a given
  time, with retry/backoff" is implemented.
- Cross-process coordination beyond the single-row `SELECT ... FOR UPDATE`
  claim (no leader election, no distributed scheduling).

## New/changed surface

- `src/job/registry.lisp`, `src/job/core.lisp` (`defjob`),
  `src/job/queue.lisp` (`enqueue-job`, claim/finalize, backoff),
  `src/job/worker.lisp` (`run-worker-tick`/`run-worker-loop`/`start-worker`/`stop-worker`),
  `src/job.lisp` (aggregator package `clails/job`).
- `log.job` added alongside the existing `log.task`/`log.sql` purpose-specific loggers.
- `clails generate:job-queue-setup` (+ `template/generate/job-queue-migration.lisp.tmpl`)
  and `clails job:work` CLI commands, wired into `roswell/clails.ros` and `src/cmd.lisp`.
- `document/job-queue.md` / `document/job-queue_ja.md` (new guide, linked from `README.md`
  and `document/command.md`).

## Test plan

- New unit/integration tests under `test/job/` (registry, `defjob`, queue,
  worker), using a dedicated migration fixture
  (`test/data/0014-job-queue-test`) following the existing hermetic
  DB-backed test pattern in `test/model/migration.lisp` (real MySQL via
  `setup`/`teardown`, with each `deftest` cleaning up after itself since
  rove only runs `setup`/`teardown` once per file).
- Retry/backoff coverage specifically:
  - `mark-job-retry-reschedules-with-backoff-test`: asserts a failed job
    goes back to `pending`, records the error, and has `available_at`
    pushed out by roughly `*default-backoff-base-seconds*`.
  - `worker-retries-then-succeeds-test`: a handler that fails twice then
    succeeds ends up `:succeeded` after exactly 3 attempts (verifies retry
    actually re-runs the handler, not just the bookkeeping).
  - `worker-fails-permanently-after-max-attempts-test`: a handler that
    always fails is marked `:failed` after exactly `max-attempts` attempts,
    with the final error message recorded in `last_error`.
  - `worker-handles-unregistered-job-name-test`: a job whose name isn't
    registered is retried like a normal failure and eventually `:failed`.
  - These bind `*default-backoff-base-seconds*` to `0` so the bounded
    `run-worker-loop :max-iterations N` calls don't have to sleep through
    real backoff windows.
- `make test`: **all 70 tests pass** (ran via a fresh `docker compose down`
  + `up -d` on `docker-compose.test.yml`, then `make test`).
- `make e2e.test` was **not** run for this change -- these changes are
  purely additive (new `clails/job` subsystem; no existing files' runtime
  behavior changed besides new exports), and the full unit suite (including
  every pre-existing test) already passes, so the regression risk to the
  existing todo-app e2e flow is very low. Happy to run it if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
